### PR TITLE
fix(mtp): make greedy verification width-invariant

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -131,6 +131,15 @@ use MTP with three draft tokens and DFlash with seven draft tokens (block length
 the optimized proposal head. DFlash accepts up to fifteen draft tokens; seven is the current
 measured recommendation rather than a semantic limit.
 
+With greedy decoding, MTP preserves the committed token sequence: for the same artifact, prepared
+prompt, KV-cache dtype, and otherwise identical Engine and request configuration, disabling MTP or
+selecting any MTP draft window from one to five produces the same token IDs. The draft window and
+proposal head may change acceptance and throughput, but not the greedy output. This contract does
+not require bit-identical logits or intermediates and does not compare different artifacts or KV
+dtypes. With stochastic sampling, speculative acceptance preserves the processed target
+distribution but does not promise the same token IDs for a fixed seed because execution may consume
+random values differently.
+
 ## Common options
 
 | Option | Meaning | Default |

--- a/docs/maintainer/qwen3.6-27b-model.md
+++ b/docs/maintainer/qwen3.6-27b-model.md
@@ -299,6 +299,14 @@ sampling mode, proposal and target probabilities use the same processed distribu
 accept/reject correction preserves the target distribution. A bad draft therefore reduces
 acceptance and throughput; it must not change the distribution of emitted target tokens.
 
+The greedy product contract is stronger than distributional equivalence. For one fixed artifact,
+prepared prompt, KV-cache dtype, and otherwise identical Engine and request configuration, MTP-off
+and MTP draft windows `1..5` must publish exactly the same committed token IDs. Draft-window and
+proposal-head choices may change acceptance and execution work only. The contract does not require
+bit-identical target logits or private intermediates and does not compare different artifacts or KV
+dtypes. Stochastic execution preserves the processed target distribution but need not reproduce the
+same token IDs for a fixed seed because its RNG consumption may differ.
+
 Target verification writes candidate KV into provisioned but unpublished extents, reads each
 lane's current GDN checkpoint, and produces Program-owned ReplaySSM records without modifying any
 persistent GDN state. After the final per-row output prefix is known, one all-layer Fold replays

--- a/docs/maintainer/qwen3.6-35b-a3b-model.md
+++ b/docs/maintainer/qwen3.6-35b-a3b-model.md
@@ -626,6 +626,14 @@ rule that preserves the processed target distribution; equality-only checking is
 for greedy decoding. Draft quality changes acceptance and throughput, never the target-model
 distribution.
 
+For MTP, greedy decoding additionally requires exact committed-token parity with ordinary decode.
+Given the same artifact, prepared prompt, KV-cache dtype, and otherwise identical Engine and request
+configuration, MTP-off and MTP draft windows `1..5` must publish the same token IDs. Draft-window and
+proposal-head choices may change acceptance and execution work only. This does not require
+bit-identical target logits or private intermediates and does not compare different artifacts or KV
+dtypes. Stochastic execution preserves the processed target distribution but need not reproduce the
+same token IDs for a fixed seed because its RNG consumption may differ.
+
 Only the target state through the anchor and accepted candidate prefix becomes committed. The
 correction or bonus is the next still-unprocessed anchor. Rejected target state and draft-query K/V
 must not remain logically reachable. Target verification writes raw per-layer ReplaySSM records

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -38,6 +38,14 @@ server must accept image or video input. Speculative residency is likewise froze
 `--lm-head-draft` additionally loads the optimized proposal head. DFlash is 35B-A3B text-only and
 cannot be combined with `--vision`. A later request cannot enable a capability omitted at startup.
 
+For a request resolved to greedy sampling, MTP preserves the committed token sequence. Holding the
+artifact, prepared prompt, KV-cache dtype, and all other Engine and request settings fixed, MTP-off
+and every MTP draft window from one to five return the same token IDs; the draft window and proposal
+head affect only acceptance and throughput. This is not a bit-identical-logit guarantee and does not
+compare different artifacts or KV dtypes. Under stochastic sampling, MTP preserves the processed
+target distribution rather than fixed-seed token identity because speculative execution may consume
+random values differently.
+
 ## Endpoints
 
 | Method and path | Behavior |

--- a/src/ops/attn_input_proj/bf16/bf16_attn_input_plan.cpp
+++ b/src/ops/attn_input_proj/bf16/bf16_attn_input_plan.cpp
@@ -4,10 +4,6 @@ namespace ninfer::ops::detail {
 
 void bf16_attn_input_dispatch(const Tensor& x, const Weight& weight, Tensor& q, Tensor& gate,
                               Tensor& k, Tensor& v, cudaStream_t stream) {
-    if (x.ne[1] == 1) {
-        bf16_attn_input_decode_launch(x, weight, q, gate, k, v, stream);
-        return;
-    }
     if (x.ne[1] <= kBf16AttnInputSmallTDispatchEnd) {
         bf16_attn_input_small_t_launch(x, weight, q, gate, k, v, stream);
         return;

--- a/src/ops/attn_input_proj/bf16/bf16_attn_input_plan.h
+++ b/src/ops/attn_input_proj/bf16/bf16_attn_input_plan.h
@@ -10,7 +10,7 @@ namespace ninfer::ops::detail {
 
 // The Attention epilogue has its own measured crossover. The wider candidate domain remains
 // benchmark-callable so the production boundary is not conflated with template availability.
-inline constexpr std::int32_t kBf16AttnInputSmallTMinTokens   = 2;
+inline constexpr std::int32_t kBf16AttnInputSmallTMinTokens   = 1;
 inline constexpr std::int32_t kBf16AttnInputSmallTMaxTokens   = 32;
 inline constexpr std::int32_t kBf16AttnInputSmallTDispatchEnd = 22;
 

--- a/src/ops/attn_input_proj/bf16/bf16_attn_input_small_t.cu
+++ b/src/ops/attn_input_proj/bf16/bf16_attn_input_small_t.cu
@@ -48,7 +48,7 @@ struct Bf16AttentionInputSmallTOutput {
 
 template <int ActiveTokens>
 struct Bf16AttentionSmallTProductionSchedule {
-    static_assert(ActiveTokens >= 2 && ActiveTokens <= 32);
+    static_assert(ActiveTokens >= 1 && ActiveTokens <= 32);
     // The Attention epilogue is measured separately from Linear, so it owns its exact-T winner
     // mapping while sharing the Linear computation body.
     static constexpr int kRowsPerWarp = ActiveTokens <= 4 ? 8 : (ActiveTokens <= 8 ? 4 : 2);
@@ -104,7 +104,7 @@ constexpr auto kLaunchers = make_launchers(
 void bf16_attn_input_small_t_launch(const Tensor& x, const Weight& weight, Tensor& q, Tensor& gate,
                                     Tensor& k, Tensor& v, cudaStream_t stream) {
     if (x.ne[1] < kBf16AttnInputSmallTMinTokens || x.ne[1] > kBf16AttnInputSmallTMaxTokens) {
-        throw std::invalid_argument("bf16 attn_input_proj small-T requires T in [2,32]");
+        throw std::invalid_argument("bf16 attn_input_proj small-T requires T in [1,32]");
     }
     kLaunchers[x.ne[1] - kBf16AttnInputSmallTMinTokens](x, weight, q, gate, k, v, stream);
 }

--- a/src/ops/attn_input_proj/nvfp4/nvfp4_attn_input_plan.cpp
+++ b/src/ops/attn_input_proj/nvfp4/nvfp4_attn_input_plan.cpp
@@ -21,7 +21,7 @@ Nvfp4AttnInputRoute resolve_route(LinearPolicy policy, std::int32_t tokens) {
     if (policy != LinearPolicy::AllowA4) {
         throw std::invalid_argument("nvfp4 attn_input_proj: unsupported policy");
     }
-    return tokens >= 4 ? Nvfp4AttnInputRoute::W4A4 : Nvfp4AttnInputRoute::A16;
+    return Nvfp4AttnInputRoute::W4A4;
 }
 
 void launch_a16(const Tensor& x, const Weight& weight, Tensor& q, Tensor& gate, Tensor& k,

--- a/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
+++ b/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
@@ -27,9 +27,10 @@ struct RouteSpec {
     Bf16GdnGatingScheduleId schedule;
 };
 
-constexpr std::array<RouteSpec, 6> k27Routes{{
-    {{1, 1}, Bf16GdnGatingScheduleId::GemvPairedRows},
-    {{2, 8}, Bf16GdnGatingScheduleId::SmallTSplit10},
+constexpr std::array<RouteSpec, 5> k27Routes{{
+    // Decode and speculative verification share one reduction profile so observable FP32 decay
+    // and update controls do not depend on the physical verification width.
+    {{1, 8}, Bf16GdnGatingScheduleId::SmallTSplit10},
     // As token tiles double, halve SplitK. This keeps the cooperative grid near 192 CTAs instead
     // of making T a launch limit. Once the unsplit grid has enough independent work, it also
     // removes the cooperative-residency constraint.
@@ -166,7 +167,7 @@ bool candidate_is_legal(Bf16GdnGatingScheduleId schedule,
         case Bf16GdnGatingScheduleId::GemvPairedRows:
             return problem.cols == 1;
         case Bf16GdnGatingScheduleId::SmallTSplit10:
-            return problem.cols >= 2 && problem.cols <= 8;
+            return problem.cols >= 1 && problem.cols <= 8;
         case Bf16GdnGatingScheduleId::MmaCooperativeSplit8:
         case Bf16GdnGatingScheduleId::MmaCooperativeSplit4:
         case Bf16GdnGatingScheduleId::MmaCooperativeSplit2:

--- a/src/ops/gdn_input_proj/nvfp4/nvfp4_gdn_snapshot_plan.cpp
+++ b/src/ops/gdn_input_proj/nvfp4/nvfp4_gdn_snapshot_plan.cpp
@@ -39,8 +39,8 @@ Nvfp4GdnConvPlan nvfp4_gdn_conv_resolve_plan(LinearPolicy policy, std::int32_t t
         if (tokens <= 16) { return {Nvfp4GdnConvScheduleId::SmallTFusedA16}; }
         throw std::invalid_argument("nvfp4 gdn conv A16 is registered only through T=16");
     }
-    if (tokens == 1) { return {Nvfp4GdnConvScheduleId::DecodeFusedA16}; }
-    if (tokens <= 3) { return {Nvfp4GdnConvScheduleId::SmallTFusedA16}; }
+    // AllowA4 owns a represented A4 activation boundary. Use it at every decode/verification
+    // width, then consume the materialized BF16 projection in the convolution/state transition.
     return {Nvfp4GdnConvScheduleId::Materialized};
 }
 

--- a/src/ops/kernel/gqa_attention_decode.cuh
+++ b/src/ops/kernel/gqa_attention_decode.cuh
@@ -144,7 +144,7 @@ __device__ __forceinline__ void gqa_small_t_tc_row_to_qt(int row, int tokens, in
 
 template <typename Geometry, int DChunk, bool Int8, bool MultiBatch, bool Masked, bool Offset>
 __launch_bounds__(256) __global__ void gqa_attention_small_t_reduce_output_kernel(
-    const __nv_bfloat16* partial_acc, const float* partial_m, const float* partial_l,
+    const void* partial_acc, const float* partial_m, const float* partial_l,
     const std::int32_t* positions, const std::int32_t* valid_columns, std::int32_t tokens,
     std::int32_t full_width, std::int32_t column_begin, std::int32_t batch_size,
     std::int32_t split_count, __nv_bfloat16* out) {
@@ -172,12 +172,12 @@ __launch_bounds__(256) __global__ void gqa_attention_small_t_reduce_output_kerne
     if constexpr (Offset) { output_column += column_begin; }
     if constexpr (MultiBatch) { output_column += batch * full_width; }
 
+    std::int64_t partial_acc_offset = 0;
     if constexpr (MultiBatch) {
-        const std::int64_t partial_acc_row = static_cast<std::int64_t>(batch) * kGqaHeadDim *
-                                             Geometry::QHeads * tokens * split_count;
+        partial_acc_offset = static_cast<std::int64_t>(batch) * kGqaHeadDim * Geometry::QHeads *
+                             tokens * split_count;
         const std::int64_t partial_stat_row =
             static_cast<std::int64_t>(batch) * Geometry::QHeads * tokens * split_count;
-        partial_acc += partial_acc_row;
         partial_m += partial_stat_row;
         partial_l += partial_stat_row;
     }
@@ -242,10 +242,17 @@ __launch_bounds__(256) __global__ void gqa_attention_small_t_reduce_output_kerne
             if (tile_l <= 0.0f) { continue; }
             const float weight = expf(
                 partial_m[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] - head_m);
-            numerator +=
-                __bfloat162float(
-                    partial_acc[gqa_partial_acc_index<Geometry>(q_head, d, token, split, tokens)]) *
-                weight;
+            const std::int64_t index = partial_acc_offset +
+                                       gqa_partial_acc_index<Geometry>(q_head, d, token, split,
+                                                                      tokens);
+            float partial = 0.0f;
+            if constexpr (Int8) {
+                partial = static_cast<const float*>(partial_acc)[index];
+            } else {
+                partial =
+                    __bfloat162float(static_cast<const __nv_bfloat16*>(partial_acc)[index]);
+            }
+            numerator += partial * weight;
         }
     }
     bool valid = true;

--- a/src/ops/kernel/gqa_attention_decode_bf16.cuh
+++ b/src/ops/kernel/gqa_attention_decode_bf16.cuh
@@ -16,7 +16,7 @@
 namespace ninfer::ops {
 
 template <typename Geometry, int TokenTile, int WarpsPerCta, bool MultiBatch, bool Masked,
-          typename CacheInput>
+          bool CanonicalColumns, typename CacheInput>
 __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_kernel(
     const __nv_bfloat16* q, CacheInput input, const std::int32_t* pos, __nv_bfloat16* cache_k,
     __nv_bfloat16* cache_v, const std::int32_t* block_tables, const std::int32_t* valid_columns,
@@ -51,25 +51,35 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
 
     const int kv_head     = static_cast<int>(blockIdx.x);
     const int split       = static_cast<int>(blockIdx.y);
-    const int batch       = MultiBatch ? static_cast<int>(blockIdx.z) : 0;
+    const int flat_column = static_cast<int>(blockIdx.z);
+    const int batch       = MultiBatch ? (CanonicalColumns ? flat_column / tokens : flat_column) : 0;
+    const int column      = CanonicalColumns ? flat_column - batch * tokens : 0;
     const int split_count = static_cast<int>(gridDim.y);
     const int tid         = static_cast<int>(threadIdx.x);
     const int warp        = tid >> 5;
     const int lane        = tid & 31;
-    int valid_tokens      = tokens;
+    const int active_tokens = CanonicalColumns ? 1 : tokens;
+    int valid_tokens        = active_tokens;
     if constexpr (Masked) {
-        const int remaining = valid_columns[batch] - column_begin;
-        valid_tokens        = remaining <= 0 ? 0 : (remaining < tokens ? remaining : tokens);
+        const int remaining = valid_columns[batch] - column_begin - column;
+        valid_tokens = remaining <= 0 ? 0 : (remaining < active_tokens ? remaining : active_tokens);
     }
-    const int row_count = tokens * Geometry::GroupSize;
+    const int row_count = active_tokens * Geometry::GroupSize;
 
-    std::int64_t column_base = column_begin;
-    if constexpr (MultiBatch) { column_base += static_cast<std::int64_t>(batch) * full_width; }
+    std::int64_t current_base = column_begin;
+    if constexpr (MultiBatch) { current_base += static_cast<std::int64_t>(batch) * full_width; }
+    const std::int32_t* current_pos = pos + current_base;
+    const int current_remaining = Masked ? valid_columns[batch] - column_begin : tokens;
+    const int current_tokens = current_remaining <= 0
+                                   ? 0
+                                   : (current_remaining < tokens ? current_remaining : tokens);
+    const std::int32_t current_first_pos = current_tokens > 0 ? current_pos[0] : -1;
+    const std::int64_t column_base       = current_base + column;
     q += static_cast<std::int64_t>(kGqaHeadDim) * Geometry::QHeads * column_base;
     pos += column_base;
     if constexpr (CacheInput::writes_cache) {
-        input.k += static_cast<std::int64_t>(kGqaHeadDim) * Geometry::KVHeads * column_base;
-        input.v += static_cast<std::int64_t>(kGqaHeadDim) * Geometry::KVHeads * column_base;
+        input.k += static_cast<std::int64_t>(kGqaHeadDim) * Geometry::KVHeads * current_base;
+        input.v += static_cast<std::int64_t>(kGqaHeadDim) * Geometry::KVHeads * current_base;
     }
     const int table_row = table_rows == nullptr ? 0 : table_rows[batch];
     const std::int32_t* block_table =
@@ -85,11 +95,13 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
         for (int row = tid; row < row_count; row += Threads) {
             int q_head = 0;
             int token  = 0;
-            gqa_small_t_tc_row_to_qt<Geometry>(row, tokens, kv_head, q_head, token);
+            gqa_small_t_tc_row_to_qt<Geometry>(row, active_tokens, kv_head, q_head, token);
+            const int output_token = column + token;
             if (gqa_valid_q_head<Geometry>(kv_head, q_head)) {
-                partial_m[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] =
+                partial_m[gqa_partial_stat_index<Geometry>(q_head, output_token, split, tokens)] =
                     -CUDART_INF_F;
-                partial_l[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = 0.0f;
+                partial_l[gqa_partial_stat_index<Geometry>(q_head, output_token, split, tokens)] =
+                    0.0f;
             }
         }
         for (int idx = tid; idx < row_count * D; idx += Threads) {
@@ -97,15 +109,18 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
             const int d   = idx - row * D;
             int q_head    = 0;
             int token     = 0;
-            gqa_small_t_tc_row_to_qt<Geometry>(row, tokens, kv_head, q_head, token);
+            gqa_small_t_tc_row_to_qt<Geometry>(row, active_tokens, kv_head, q_head, token);
+            const int output_token = column + token;
             if (gqa_valid_q_head<Geometry>(kv_head, q_head)) {
-                partial_acc[gqa_partial_acc_index<Geometry>(q_head, d, token, split, tokens)] =
+                partial_acc[
+                    gqa_partial_acc_index<Geometry>(q_head, d, output_token, split, tokens)] =
                     __float2bfloat16(0.0f);
             }
         }
     };
 
-    if (kv_head < 0 || kv_head >= Geometry::KVHeads || tokens < 1 || tokens > TokenTile ||
+    if (kv_head < 0 || kv_head >= Geometry::KVHeads || active_tokens < 1 ||
+        active_tokens > TokenTile || column < 0 || column >= tokens ||
         row_count > Br || split_count <= 0) {
         return;
     }
@@ -115,7 +130,7 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
     }
 
     const std::int32_t first_pos = pos[0];
-    const std::int32_t last_pos  = pos[tokens - 1];
+    const std::int32_t last_pos  = pos[active_tokens - 1];
     if (first_pos < 0 || last_pos < 0 || last_pos >= logical_capacity) {
         write_neutral();
         return;
@@ -154,7 +169,9 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
             const int p_tok = pos[token];
             if (p_tok >= split_start && p_tok < split_end && p_tok >= 0 &&
                 p_tok < logical_capacity) {
-                const std::int64_t new_off = gqa_kv_new_index<Geometry>(kv_head, d, token);
+                const int input_token = CanonicalColumns ? column + token : token;
+                const std::int64_t new_off =
+                    gqa_kv_new_index<Geometry>(kv_head, d, input_token);
                 const int lane             = tid & 31;
                 int physical_page = lane == 0 ? paged_kv_physical_page(block_table, p_tok) : 0;
                 physical_page     = __shfl_sync(FullMask, physical_page, 0);
@@ -172,7 +189,7 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
         const int d   = idx - row * D;
         int q_head    = 0;
         int token     = 0;
-        gqa_small_t_tc_row_to_qt<Geometry>(row, tokens, kv_head, q_head, token);
+        gqa_small_t_tc_row_to_qt<Geometry>(row, active_tokens, kv_head, q_head, token);
         __nv_bfloat16 value = __float2bfloat16(0.0f);
         if (row < row_count && gqa_valid_q_head<Geometry>(kv_head, q_head)) {
             value = q[gqa_q_index<Geometry>(q_head, d, token)];
@@ -228,9 +245,8 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
             __nv_bfloat16* v_dst = &v_s[key_l * D + gqa_small_t_tc_swz(key_l, d)];
             if (key >= split_start && key < split_end) {
                 if constexpr (CacheInput::writes_cache) {
-                    const int new_token = key - first_pos;
-                    const bool from_new =
-                        new_token >= 0 && new_token < valid_tokens && key >= first_pos;
+                    const int new_token = key - current_first_pos;
+                    const bool from_new = new_token >= 0 && new_token < current_tokens;
                     if (from_new) {
                         const std::int64_t off = gqa_kv_new_index<Geometry>(kv_head, d, new_token);
                         ninfer::ops::cp_async<16>(k_dst, &input.k[off]);
@@ -275,8 +291,8 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
         const int row0 = warp_row0 + gid;
         const int row1 = row0 + 8;
         int q_head0 = 0, token0 = 0, q_head1 = 0, token1 = 0;
-        gqa_small_t_tc_row_to_qt<Geometry>(row0, tokens, kv_head, q_head0, token0);
-        gqa_small_t_tc_row_to_qt<Geometry>(row1, tokens, kv_head, q_head1, token1);
+        gqa_small_t_tc_row_to_qt<Geometry>(row0, active_tokens, kv_head, q_head0, token0);
+        gqa_small_t_tc_row_to_qt<Geometry>(row1, active_tokens, kv_head, q_head1, token1);
         const int qabs0 = (row0 < row_count) ? pos[token0] : -1;
         const int qabs1 = (row1 < row_count) ? pos[token1] : -1;
 
@@ -380,16 +396,18 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
         if (row0 < row_count) {
             int q_head = 0;
             int token  = 0;
-            gqa_small_t_tc_row_to_qt<Geometry>(row0, tokens, kv_head, q_head, token);
-            partial_m[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = m0;
-            partial_l[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = l0;
+            gqa_small_t_tc_row_to_qt<Geometry>(row0, active_tokens, kv_head, q_head, token);
+            const int output_token = column + token;
+            partial_m[gqa_partial_stat_index<Geometry>(q_head, output_token, split, tokens)] = m0;
+            partial_l[gqa_partial_stat_index<Geometry>(q_head, output_token, split, tokens)] = l0;
         }
         if (row1 < row_count) {
             int q_head = 0;
             int token  = 0;
-            gqa_small_t_tc_row_to_qt<Geometry>(row1, tokens, kv_head, q_head, token);
-            partial_m[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = m1;
-            partial_l[gqa_partial_stat_index<Geometry>(q_head, token, split, tokens)] = l1;
+            gqa_small_t_tc_row_to_qt<Geometry>(row1, active_tokens, kv_head, q_head, token);
+            const int output_token = column + token;
+            partial_m[gqa_partial_stat_index<Geometry>(q_head, output_token, split, tokens)] = m1;
+            partial_l[gqa_partial_stat_index<Geometry>(q_head, output_token, split, tokens)] = l1;
         }
     }
 
@@ -417,10 +435,11 @@ __launch_bounds__(128, 2) __global__ void gqa_attention_small_t_tc_partial_bf16_
         const int d   = (chunk - row * (D / 8)) * 8;
         int q_head    = 0;
         int token     = 0;
-        gqa_small_t_tc_row_to_qt<Geometry>(row, tokens, kv_head, q_head, token);
+        gqa_small_t_tc_row_to_qt<Geometry>(row, active_tokens, kv_head, q_head, token);
+        const int output_token = column + token;
         if (gqa_valid_q_head<Geometry>(kv_head, q_head)) {
             const std::int64_t dst =
-                gqa_partial_acc_index<Geometry>(q_head, d, token, split, tokens);
+                gqa_partial_acc_index<Geometry>(q_head, d, output_token, split, tokens);
             store_vec(&partial_acc[dst], load_vec<int4>(&qkv_s[row * D + d]));
         }
     }

--- a/src/ops/kernel/gqa_attention_decode_i8.cuh
+++ b/src/ops/kernel/gqa_attention_decode_i8.cuh
@@ -63,7 +63,7 @@ __launch_bounds__(WarpsPerCta * 32, MinBlocksPerSm) __global__
         const std::int32_t* block_tables, const std::int32_t* valid_columns,
         const std::int32_t* table_rows, std::int32_t table_stride, std::int32_t full_width,
         std::int32_t column_begin, std::int32_t logical_capacity, float scale,
-        __nv_bfloat16* partial_acc, float* partial_m, float* partial_l) {
+        float* partial_acc, float* partial_m, float* partial_l) {
     constexpr int Wc                   = WarpsPerCta;
     constexpr int RowCount             = TokenTile * Geometry::GroupSize;
     constexpr int RowTiles             = (RowCount + 15) / 16;
@@ -164,7 +164,7 @@ __launch_bounds__(WarpsPerCta * 32, MinBlocksPerSm) __global__
             gqa_small_t_tc_row_to_qt<Geometry>(row, TokenTile, kv_head, q_head, token);
             if (gqa_valid_q_head<Geometry>(kv_head, q_head)) {
                 partial_acc[gqa_partial_acc_index<Geometry>(q_head, d, token, split, TokenTile)] =
-                    __float2bfloat16(0.0f);
+                    0.0f;
             }
         }
     };
@@ -592,7 +592,8 @@ __launch_bounds__(WarpsPerCta * 32, MinBlocksPerSm) __global__
             gqa_small_t_tc_row_to_qt<Geometry>(row0, TokenTile, kv_head, q_head, token);
             const std::int64_t dst =
                 gqa_partial_acc_index<Geometry>(q_head, d0, token, split, TokenTile);
-            *reinterpret_cast<unsigned*>(&partial_acc[dst]) = pack_bf16x2(acc[n][0], acc[n][1]);
+            partial_acc[dst]     = acc[n][0];
+            partial_acc[dst + 1] = acc[n][1];
         }
         if (row1 < RowCount) {
             int q_head = 0;
@@ -600,7 +601,8 @@ __launch_bounds__(WarpsPerCta * 32, MinBlocksPerSm) __global__
             gqa_small_t_tc_row_to_qt<Geometry>(row1, TokenTile, kv_head, q_head, token);
             const std::int64_t dst =
                 gqa_partial_acc_index<Geometry>(q_head, d0, token, split, TokenTile);
-            *reinterpret_cast<unsigned*>(&partial_acc[dst]) = pack_bf16x2(acc[n][2], acc[n][3]);
+            partial_acc[dst]     = acc[n][2];
+            partial_acc[dst + 1] = acc[n][3];
         }
     }
 }

--- a/src/ops/launcher/gqa_attention_decode.cu
+++ b/src/ops/launcher/gqa_attention_decode.cu
@@ -82,19 +82,21 @@ std::int32_t gqa_small_t_launch_capacity(GqaExecutionEnvelope envelope, std::int
     return capacity;
 }
 
-template <typename Geometry, int TokenTile, int WarpsPerCta, bool MultiBatch, bool Masked,
-          typename CacheInput>
+template <typename Geometry, bool MultiBatch, bool Masked, typename CacheInput>
 void launch_tc_partial_bf16(const Tensor& q, CacheInput input, const Tensor& pos, float scale,
                             PagedKVBatchLayerView cache, const GqaSmallTInvocation& invocation,
                             std::int32_t logical_capacity, std::int32_t splits, Tensor& partial_acc,
                             Tensor& partial_m, Tensor& partial_l, cudaStream_t stream) {
-    constexpr int kBlock = 32 * WarpsPerCta;
-    const dim3 grid(Geometry::KVHeads, splits, invocation.batch_size);
+    constexpr int kTokenTile   = 1;
+    constexpr int kWarpsPerCta = 2;
+    constexpr int kBlock       = 32 * kWarpsPerCta;
+    const dim3 grid(Geometry::KVHeads, splits, invocation.batch_size * invocation.width);
     Tensor& cache_k = cache.k_pages;
     Tensor& cache_v = cache.v_pages;
     // bf16 kernel uses only static smem (no dynamic staging).
-    gqa_attention_small_t_tc_partial_bf16_kernel<Geometry, TokenTile, WarpsPerCta, MultiBatch,
-                                                 Masked, CacheInput><<<grid, kBlock, 0, stream>>>(
+    gqa_attention_small_t_tc_partial_bf16_kernel<Geometry, kTokenTile, kWarpsPerCta, MultiBatch,
+                                                 Masked, true, CacheInput>
+        <<<grid, kBlock, 0, stream>>>(
         static_cast<const __nv_bfloat16*>(q.data), input,
         static_cast<const std::int32_t*>(pos.data), static_cast<__nv_bfloat16*>(cache_k.data),
         static_cast<__nv_bfloat16*>(cache_v.data),
@@ -148,7 +150,7 @@ void launch_tc_partial_i8(const Tensor& q, CacheInput input, const Tensor& pos, 
                     ? nullptr
                     : static_cast<const std::int32_t*>(invocation.table_rows->data),
                 cache.block_tables.ne[0], invocation.full_width, invocation.column_begin,
-                logical_capacity, scale, static_cast<__nv_bfloat16*>(partial_acc.data),
+                logical_capacity, scale, static_cast<float*>(partial_acc.data),
                 static_cast<float*>(partial_m.data), static_cast<float*>(partial_l.data));
     };
     if constexpr (TokenTile == 6) {
@@ -244,9 +246,9 @@ void gqa_attention_small_t_launch_for(const Tensor& q, CacheInput input, const T
     const auto splits =
         gqa_small_t_launch_capacity<Geometry>(envelope, invocation.width, cache.dtype);
 
-    // BF16 keeps its row-tile warp count; INT8 selects its producer/consumer
-    // geometry inside launch_tc_partial_i8.
-#define NINFER_GQA_SMALL_T_DISPATCH(TOKENS, WARPS)                                                 \
+    // BF16 uses its fixed canonical-column geometry; INT8 selects a token-specialized
+    // producer/consumer geometry inside launch_tc_partial_i8.
+#define NINFER_GQA_SMALL_T_DISPATCH(TOKENS)                                                        \
     do {                                                                                           \
         const auto launch_profile = [&]<bool MultiBatch, bool Masked>() {                          \
             if (cache.dtype == DType::I8) {                                                        \
@@ -254,7 +256,7 @@ void gqa_attention_small_t_launch_for(const Tensor& q, CacheInput input, const T
                     q, input, pos, scale, cache, invocation, logical_capacity,                     \
                     implementation_window, splits, partial_acc, partial_m, partial_l, stream);     \
             } else {                                                                               \
-                launch_tc_partial_bf16<Geometry, (TOKENS), (WARPS), MultiBatch, Masked>(           \
+                launch_tc_partial_bf16<Geometry, MultiBatch, Masked>(                              \
                     q, input, pos, scale, cache, invocation, logical_capacity, splits,             \
                     partial_acc, partial_m, partial_l, stream);                                    \
             }                                                                                      \
@@ -275,22 +277,22 @@ void gqa_attention_small_t_launch_for(const Tensor& q, CacheInput input, const T
 
     switch (invocation.width) {
     case 1:
-        NINFER_GQA_SMALL_T_DISPATCH(1, 2);
+        NINFER_GQA_SMALL_T_DISPATCH(1);
         break;
     case 2:
-        NINFER_GQA_SMALL_T_DISPATCH(2, 4);
+        NINFER_GQA_SMALL_T_DISPATCH(2);
         break;
     case 3:
-        NINFER_GQA_SMALL_T_DISPATCH(3, 4);
+        NINFER_GQA_SMALL_T_DISPATCH(3);
         break;
     case 4:
-        NINFER_GQA_SMALL_T_DISPATCH(4, 4);
+        NINFER_GQA_SMALL_T_DISPATCH(4);
         break;
     case 5:
-        NINFER_GQA_SMALL_T_DISPATCH(5, 4);
+        NINFER_GQA_SMALL_T_DISPATCH(5);
         break;
     case 6:
-        NINFER_GQA_SMALL_T_DISPATCH(6, 4);
+        NINFER_GQA_SMALL_T_DISPATCH(6);
         break;
     default:
         throw std::invalid_argument("gqa_attention_small_t_launch: unsupported T");
@@ -305,7 +307,7 @@ void gqa_attention_small_t_launch_for(const Tensor& q, CacheInput input, const T
         gqa_attention_small_t_reduce_output_kernel<Geometry, kDChunk, Int8, MultiBatch, Masked,
                                                    Offset>
             <<<reduce_grid, kReduceBlock, 0, stream>>>(
-                static_cast<const __nv_bfloat16*>(partial_acc.data),
+                partial_acc.data,
                 static_cast<const float*>(partial_m.data),
                 static_cast<const float*>(partial_l.data),
                 static_cast<const std::int32_t*>(pos.data),

--- a/src/ops/linear/bf16/bf16_small_t.cuh
+++ b/src/ops/linear/bf16/bf16_small_t.cuh
@@ -180,7 +180,7 @@ __global__
 __launch_bounds__(Schedule::kThreads, Schedule::kMinBlocksPerSm) void bf16_small_t_inner_kernel(
     const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ weight,
     OutputPolicy output) {
-    static_assert(ActiveTokens >= 2 && ActiveTokens <= 32);
+    static_assert(ActiveTokens >= 1 && ActiveTokens <= 32);
     static_assert((Geometry::kOutputRows % Schedule::kRowsPerCta) == 0);
 
     __shared__ Bf16SmallTSharedStorage<Schedule, ActiveTokens> shared;

--- a/src/ops/linear/nvfp4/nvfp4_config.h
+++ b/src/ops/linear/nvfp4/nvfp4_config.h
@@ -188,17 +188,16 @@ struct Nvfp4LinearSmallTProductionSchedule {
                             Nvfp4SmallTBlockOrder::RowsContiguous, 1>;
 };
 
-// G1's wider N benefits from keeping four warps per CTA throughout the A16 policy boundary. Only
-// T=2 amortizes activation traffic enough for shared staging to win.
+// G1's wider N benefits from keeping four warps per CTA throughout the A16 policy boundary. Decode
+// and every supported speculative width share the token-packed reduction profile so fused
+// projection/convolution results do not depend on the physical verification width.
 template <int ActiveTokens>
 struct Nvfp4LinearSmallTProductionSchedule<Nvfp4GdnInputGeometry, ActiveTokens> {
-    static_assert(ActiveTokens >= kNvfp4FirstSmallT);
+    static_assert(ActiveTokens >= 1);
     static_assert(ActiveTokens <= kNvfp4LastSmallT);
     static constexpr int kWarpsPerCta       = 4;
     static constexpr int kValuesPerLane     = ActiveTokens >= 17 && ActiveTokens <= 20 ? 8 : 16;
-    static constexpr auto kActivationAccess = ActiveTokens == 2
-                                                  ? Nvfp4SmallTActivationAccess::SharedPhase
-                                                  : Nvfp4SmallTActivationAccess::TokenPacked;
+    static constexpr auto kActivationAccess = Nvfp4SmallTActivationAccess::TokenPacked;
     using Type =
         Nvfp4SmallTSchedule<kWarpsPerCta, 1, 2, kValuesPerLane, ActiveTokens, 1, kActivationAccess,
                             Nvfp4ScaleAccess::Direct, Nvfp4CodeCache::Default, 1,
@@ -209,7 +208,7 @@ struct Nvfp4LinearSmallTProductionSchedule<Nvfp4GdnInputGeometry, ActiveTokens> 
 // A16-only tail keeps the established generic schedule.
 template <int ActiveTokens>
 struct Nvfp4LinearSmallTProductionSchedule<Nvfp4Residual6144Geometry, ActiveTokens> {
-    static_assert(ActiveTokens >= kNvfp4FirstSmallT);
+    static_assert(ActiveTokens >= 1);
     static_assert(ActiveTokens <= kNvfp4LastSmallT);
     static constexpr int kWarpsPerCta   = ActiveTokens <= 16 ? (ActiveTokens >= 14 ? 16 : 4) : 4;
     static constexpr int kValuesPerLane = ActiveTokens >= 17 && ActiveTokens <= 20 ? 8 : 16;

--- a/src/ops/linear/nvfp4/nvfp4_small_t.cuh
+++ b/src/ops/linear/nvfp4/nvfp4_small_t.cuh
@@ -212,7 +212,7 @@ __launch_bounds__(Schedule::kThreads, Schedule::kMinBlocksPerSm) void nvfp4_smal
     const __nv_bfloat16* __restrict__ x, const std::uint8_t* __restrict__ codes,
     const std::uint8_t* __restrict__ scales, float inverse_weight_divisor, Epilogue epilogue,
     OutputPolicy output) {
-    static_assert(ActiveTokens >= 2);
+    static_assert(ActiveTokens >= 1);
     static_assert(Schedule::kTokenTile <= ActiveTokens);
     static_assert((Geometry::kOutputRows % 128) == 0);
     static_assert((Schedule::kRowsPerCta % 4) == 0);

--- a/src/ops/linear_add/bf16/bf16_linear_add_plan.cpp
+++ b/src/ops/linear_add/bf16/bf16_linear_add_plan.cpp
@@ -14,7 +14,6 @@ Bf16LinearAddScheduleId bf16_linear_add_select(std::int32_t output_rows, std::in
     if (!bf16_linear_add_admits(output_rows, input_rows, tokens)) {
         throw std::invalid_argument("bf16 linear_add: unsupported exact problem");
     }
-    if (tokens == 1) { return Bf16LinearAddScheduleId::Decode; }
     if (tokens <= kBf16LinearAddSmallTDispatchEnd) { return Bf16LinearAddScheduleId::SmallT; }
     if (tokens <= kBf16LinearAddAggregateMmaEnd) { return Bf16LinearAddScheduleId::AggregateMma; }
     return Bf16LinearAddScheduleId::Mma;

--- a/src/ops/linear_add/bf16/bf16_linear_add_plan.h
+++ b/src/ops/linear_add/bf16/bf16_linear_add_plan.h
@@ -8,9 +8,9 @@
 
 namespace ninfer::ops::detail {
 
-inline constexpr std::int32_t kBf16LinearAddSmallTMinTokens   = 2;
+inline constexpr std::int32_t kBf16LinearAddSmallTMinTokens   = 1;
 inline constexpr std::int32_t kBf16LinearAddSmallTMaxTokens   = 32;
-inline constexpr std::int32_t kBf16LinearAddSmallTDispatchEnd = 4;
+inline constexpr std::int32_t kBf16LinearAddSmallTDispatchEnd = 6;
 inline constexpr std::int32_t kBf16LinearAddAggregateMmaEnd   = 48;
 
 enum class Bf16LinearAddScheduleId : std::uint8_t {

--- a/src/ops/linear_add/bf16/bf16_linear_add_small_t.cu
+++ b/src/ops/linear_add/bf16/bf16_linear_add_small_t.cu
@@ -27,9 +27,23 @@ struct Bf16LinearAddSmallTOutput {
 };
 
 template <int ActiveTokens>
+struct Bf16LinearAddSmallTProductionSchedule {
+    static_assert(ActiveTokens >= 1 && ActiveTokens <= kBf16LinearAddSmallTMaxTokens);
+    // The residual update is an observable BF16 state boundary. Keep one contraction reduction
+    // profile across decode and every supported speculative width while retaining each width's
+    // independent row occupancy choice.
+    static constexpr int kRowsPerWarp =
+        (ActiveTokens == 4 || ActiveTokens == 6) ? 2 : (ActiveTokens <= 8 ? 4 : 2);
+    using Type = Bf16SmallTInnerSchedule<4, 1, kRowsPerWarp, 16, 1, 4,
+                                         Bf16SmallTActivationAccess::WarpPacked,
+                                         Bf16WeightCache::Default, Bf16PhaseOrder::Sequential, 1,
+                                         2, 1, 2>;
+};
+
+template <int ActiveTokens>
 void launch_exact(const Tensor& x, const Weight& weight, Tensor& residual, cudaStream_t stream) {
     using Geometry = Bf16GemvGeometry<5120, 6144>;
-    using Schedule = typename Bf16LinearSmallTProductionSchedule<Geometry, ActiveTokens>::Type;
+    using Schedule = typename Bf16LinearAddSmallTProductionSchedule<ActiveTokens>::Type;
     static_assert((Geometry::kOutputRows % Schedule::kRowsPerCta) == 0);
 
     const Bf16LinearAddSmallTOutput output{static_cast<__nv_bfloat16*>(residual.data),

--- a/src/ops/linear_add/nvfp4/nvfp4_linear_add_plan.cpp
+++ b/src/ops/linear_add/nvfp4/nvfp4_linear_add_plan.cpp
@@ -23,8 +23,10 @@ Nvfp4LinearAddRoute resolve_route(std::int32_t output_rows, std::int32_t input_r
     if (policy != LinearPolicy::AllowA4) {
         throw std::invalid_argument("nvfp4 linear_add: unsupported policy");
     }
-    const std::int32_t first_w4a4 = input_rows == 6144 ? 7 : 8;
-    return tokens >= first_w4a4 ? Nvfp4LinearAddRoute::W4A4 : Nvfp4LinearAddRoute::A16;
+    // MLP down projection consumes the represented A4 activation at every execution width. The
+    // GDN output projection retains its A16 path through the supported speculative frontier.
+    if (input_rows == 17408 || tokens >= 7) { return Nvfp4LinearAddRoute::W4A4; }
+    return Nvfp4LinearAddRoute::A16;
 }
 
 void launch_a16(const Tensor& x, const Weight& weight, Tensor& residual, cudaStream_t stream) {
@@ -37,7 +39,9 @@ void launch_a16(const Tensor& x, const Weight& weight, Tensor& residual, cudaStr
                        static_cast<std::int64_t>(token_begin) * weight.n * sizeof(std::uint16_t);
         Tensor input_chunk(input, DType::BF16, {weight.k, active});
         Tensor residual_chunk(output, DType::BF16, {weight.n, active});
-        if (active == 1) {
+        // The 6144-wide GDN output projection uses one reduction profile for decode and
+        // speculative verification so the residual update is independent of physical width.
+        if (active == 1 && weight.k != 6144) {
             nvfp4_linear_add_decode_launch(input_chunk, weight, residual_chunk, stream);
         } else {
             nvfp4_linear_add_small_t_launch(input_chunk, weight, residual_chunk, stream);

--- a/src/ops/linear_add/nvfp4/nvfp4_linear_add_small_t.cu
+++ b/src/ops/linear_add/nvfp4/nvfp4_linear_add_small_t.cu
@@ -51,8 +51,13 @@ constexpr auto kResidual17408Launchers = make_launchers<Nvfp4Residual17408Geomet
 
 void nvfp4_linear_add_small_t_launch(const Tensor& x, const Weight& weight, Tensor& residual,
                                      cudaStream_t stream) {
+    const Nvfp4Problem problem = resolve_nvfp4_problem(weight.n, weight.k);
+    if (x.ne[1] == 1 && problem == Nvfp4Problem::Residual6144) {
+        launch_exact<Nvfp4Residual6144Geometry, 1>(x, weight, residual, stream);
+        return;
+    }
     const std::size_t index = static_cast<std::size_t>(x.ne[1] - kNvfp4FirstSmallT);
-    switch (resolve_nvfp4_problem(weight.n, weight.k)) {
+    switch (problem) {
     case Nvfp4Problem::Residual6144:
         kResidual6144Launchers[index](x, weight, residual, stream);
         return;

--- a/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.cpp
+++ b/src/ops/linear_swiglu/nvfp4/nvfp4_linear_swiglu_plan.cpp
@@ -33,8 +33,6 @@ Nvfp4LinearSwiGluRoute resolve_route(LinearPolicy policy, std::int32_t tokens) {
         if (tokens <= 16) { return Nvfp4LinearSwiGluRoute::SmallTFusedA16; }
         throw std::invalid_argument("nvfp4 linear_swiglu A16 is registered only through T=16");
     }
-    if (tokens == 1) { return Nvfp4LinearSwiGluRoute::DecodeFusedA16; }
-    if (tokens <= 4) { return Nvfp4LinearSwiGluRoute::SmallTFusedA16; }
     if (tokens <= 48) { return Nvfp4LinearSwiGluRoute::FusedW4A4; }
     if (tokens == kPrimaryT) { return Nvfp4LinearSwiGluRoute::TmaFusedW4A4; }
     return Nvfp4LinearSwiGluRoute::LinearW4A4Post;
@@ -84,10 +82,10 @@ std::size_t nvfp4_linear_swiglu_workspace_capacity_bytes(LinearPolicy policy,
     }
     (void)resolve_route(policy, min_tokens);
     (void)resolve_route(policy, max_tokens);
-    if (policy == LinearPolicy::A16Only || max_tokens <= 4) { return 0; }
+    if (policy == LinearPolicy::A16Only) { return 0; }
 
     std::size_t maximum = 0;
-    if (min_tokens <= 48 && max_tokens >= 5) {
+    if (min_tokens <= 48) {
         maximum = fused_workspace_bytes(std::min(max_tokens, 48));
     }
     if (min_tokens <= kPrimaryT && max_tokens >= kPrimaryT) {

--- a/src/ops/wrapper/gdn_input_proj.cpp
+++ b/src/ops/wrapper/gdn_input_proj.cpp
@@ -900,8 +900,8 @@ std::size_t gdn_input_proj_conv_record_workspace_capacity_bytes(
             throw std::logic_error("ReplaySSM record planner admitted NVFP4 decode");
         }
         if (maximum_plan.schedule == detail::Nvfp4GdnConvScheduleId::SmallTFusedA16) { return 0; }
-        return detail::nvfp4_gdn_input_workspace_capacity_bytes(LinearPolicy::AllowA4,
-                                                                std::max(min_width, 4), max_width);
+        return detail::nvfp4_gdn_input_workspace_capacity_bytes(LinearPolicy::AllowA4, min_width,
+                                                                 max_width);
     }
     return detail::nvfp4_gdn_input_workspace_capacity_bytes(policy, batch_size * min_width,
                                                             batch_size * max_width);

--- a/src/ops/wrapper/gqa_attention.cpp
+++ b/src/ops/wrapper/gqa_attention.cpp
@@ -262,9 +262,11 @@ struct SmallTWorkspace {
 template <class Allocator>
 SmallTWorkspace allocate_small_t_workspace(Allocator& workspace, std::int32_t q_heads,
                                            std::int32_t tokens, std::int32_t splits,
+                                           DType cache_dtype,
                                            std::int32_t batch_size = 1) {
     return {
-        workspace.alloc(DType::BF16, {kHeadDim, q_heads, tokens, splits * batch_size}),
+        workspace.alloc(cache_dtype == DType::I8 ? DType::FP32 : DType::BF16,
+                        {kHeadDim, q_heads, tokens, splits * batch_size}),
         workspace.alloc(DType::FP32, {q_heads, tokens, splits * batch_size}),
         workspace.alloc(DType::FP32, {q_heads, tokens, splits * batch_size}),
     };
@@ -279,7 +281,8 @@ void for_each_small_t_chunk(const Tensor& q, const Tensor& positions, WorkspaceA
         auto chunk_scope         = workspace.scope();
         const std::int32_t splits =
             detail::gqa_attention_split_capacity(q.ne[1], count, cache_dtype, envelope);
-        SmallTWorkspace partial = allocate_small_t_workspace(workspace, q.ne[1], count, splits);
+        SmallTWorkspace partial =
+            allocate_small_t_workspace(workspace, q.ne[1], count, splits, cache_dtype);
         Tensor q_chunk          = q.slice(2, begin, count);
         Tensor position_chunk   = positions.slice(0, begin, count);
         Tensor out_chunk        = out.slice(2, begin, count);
@@ -291,14 +294,14 @@ void launch_chunked_small_t(const Tensor& q, const Tensor& k, const Tensor& v,
                             const Tensor& positions, const Tensor& valid_columns,
                             const Tensor& table_rows, float scale, PagedKVBatchLayerView cache,
                             GqaExecutionEnvelope envelope, WorkspaceArena& workspace, Tensor& out,
-                            cudaStream_t stream) {
-    for (std::int32_t begin = 0; begin < q.ne[2]; begin += kSmallTChunkTokens) {
-        const std::int32_t count = std::min(kSmallTChunkTokens, q.ne[2] - begin);
+                            std::int32_t chunk_tokens, cudaStream_t stream) {
+    for (std::int32_t begin = 0; begin < q.ne[2]; begin += chunk_tokens) {
+        const std::int32_t count = std::min(chunk_tokens, q.ne[2] - begin);
         auto chunk_scope         = workspace.scope();
         const std::int32_t splits =
             detail::gqa_attention_split_capacity(q.ne[1], count, cache.dtype, envelope);
         SmallTWorkspace partial =
-            allocate_small_t_workspace(workspace, q.ne[1], count, splits, q.ne[3]);
+            allocate_small_t_workspace(workspace, q.ne[1], count, splits, cache.dtype, q.ne[3]);
         detail::gqa_attention_small_t_launch(q, k, v, positions, valid_columns, table_rows, scale,
                                              cache, envelope, begin, count, partial.acc, partial.m,
                                              partial.l, out, stream);
@@ -368,14 +371,17 @@ std::size_t gqa_attention_workspace_capacity_bytes(std::int32_t q_heads, DType c
         const std::int32_t splits =
             detail::gqa_attention_split_capacity(q_heads, width, cache_dtype, envelope);
         WorkspaceLayoutBuilder layout;
-        (void)allocate_small_t_workspace(layout, q_heads, width, splits, batch_size);
+        (void)allocate_small_t_workspace(layout, q_heads, width, splits, cache_dtype, batch_size);
         return layout.peak_bytes(1);
     };
     const auto exact_capacity = [&](std::int32_t width) {
         const detail::GqaAttentionRoute route =
             detail::gqa_attention_resolve_route(q_heads, width, batch_size, envelope);
         if (route == detail::GqaAttentionRoute::Prompt) { return std::size_t{0}; }
-        if (route == detail::GqaAttentionRoute::SmallT) { return chunk_capacity(width); }
+        if (route == detail::GqaAttentionRoute::SmallT) {
+            return cache_dtype == DType::I8 && width > 1 ? chunk_capacity(1)
+                                                         : chunk_capacity(width);
+        }
         std::size_t maximum = 0;
         for (std::int32_t begin = 0; begin < width; begin += kSmallTChunkTokens) {
             maximum =
@@ -415,16 +421,24 @@ void gqa_attention(const Tensor& q, const Tensor& k, const Tensor& v, const Tens
     auto scope = workspace.scope();
     const detail::GqaAttentionRoute route =
         detail::gqa_attention_resolve_route(q.ne[1], width, batch, envelope);
+    if (cache.dtype == DType::I8 && width > 1 && width <= kSmallTChunkTokens) {
+        // INT8's producer geometry is specialized by compile-time token tile. Publish and attend
+        // one causal column at a time so every committed query uses the exact decode arithmetic;
+        // the shared workspace is reused across columns.
+        launch_chunked_small_t(q, k, v, positions, valid_columns, kv_table_rows, scale, cache,
+                               envelope, workspace, out, 1, stream);
+        return;
+    }
     if (route == detail::GqaAttentionRoute::ChunkedSmallT) {
         launch_chunked_small_t(q, k, v, positions, valid_columns, kv_table_rows, scale, cache,
-                               envelope, workspace, out, stream);
+                               envelope, workspace, out, kSmallTChunkTokens, stream);
         return;
     }
     if (route == detail::GqaAttentionRoute::SmallT) {
         const std::int32_t splits =
             detail::gqa_attention_split_capacity(q.ne[1], width, cache.dtype, envelope);
         SmallTWorkspace partial =
-            allocate_small_t_workspace(workspace, q.ne[1], width, splits, batch);
+            allocate_small_t_workspace(workspace, q.ne[1], width, splits, cache.dtype, batch);
         detail::gqa_attention_small_t_launch(q, k, v, positions, valid_columns, kv_table_rows,
                                              scale, cache, envelope, 0, width, partial.acc,
                                              partial.m, partial.l, out, stream);
@@ -475,7 +489,8 @@ void gqa_attention_cached(const Tensor& q, const Tensor& positions, float scale,
     if (detail::gqa_attention_uses_small_t(q.ne[2])) {
         const std::int32_t splits =
             detail::gqa_attention_split_capacity(q.ne[1], q.ne[2], cache.dtype, envelope);
-        SmallTWorkspace partial = allocate_small_t_workspace(workspace, q.ne[1], q.ne[2], splits);
+        SmallTWorkspace partial =
+            allocate_small_t_workspace(workspace, q.ne[1], q.ne[2], splits, cache.dtype);
         detail::gqa_attention_cached_small_t_launch(q, positions, scale, cache, envelope,
                                                     partial.acc, partial.m, partial.l, out, stream);
         return;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,11 @@ ninfer_add_test(ninfer_qwen3_6_27b_prefix_real_test
   SOURCES targets/qwen3_6_27b/test_engine_prefix_real.cpp
   LIBRARIES ninfer_engine)
 set_tests_properties(ninfer_qwen3_6_27b_prefix_real_test PROPERTIES SKIP_RETURN_CODE 77)
+ninfer_add_test(ninfer_qwen3_6_27b_mtp_greedy_parity_real_test
+  SOURCES targets/qwen3_6_27b/test_engine_mtp_greedy_parity_real.cpp
+  LIBRARIES ninfer_engine)
+set_tests_properties(ninfer_qwen3_6_27b_mtp_greedy_parity_real_test
+  PROPERTIES SKIP_RETURN_CODE 77)
 ninfer_add_test(ninfer_qwen3_6_27b_load_plan_test
   SOURCES targets/qwen3_6_27b/test_load_plan.cpp
   NEEDS_SOURCE_DIR

--- a/tests/ops/linear_add/test_nvfp4.cpp
+++ b/tests/ops/linear_add/test_nvfp4.cpp
@@ -87,7 +87,7 @@ int verify_preserved(const GuardedDeviceBuffer& device, std::span<const std::uin
 }
 
 int run_shape(std::int32_t n, std::int32_t k, std::uint32_t seed) {
-    const std::int32_t first_a4 = k == 6144 ? 7 : 8;
+    const std::int32_t first_a4 = k == 17408 ? 1 : (k == 6144 ? 7 : 8);
     const std::array invocations{
         Invocation{1, ops::LinearPolicy::A16Only},
         Invocation{4, ops::LinearPolicy::A16Only},

--- a/tests/ops/linear_swiglu/test_nvfp4.cpp
+++ b/tests/ops/linear_swiglu/test_nvfp4.cpp
@@ -10,7 +10,7 @@ int main() {
 
     try {
         constexpr std::array<std::int32_t, 4> kA16Cases{1, 4, 8, 16};
-        constexpr std::array<std::int32_t, 5> kA4Cases{5, 48, 49, 128, 1024};
+        constexpr std::array<std::int32_t, 9> kA4Cases{1, 2, 3, 4, 5, 48, 49, 128, 1024};
         int failures = 0;
         failures += run_profile("LinearSwiGLU NVFP4_A16",
                                 {QType::NVFP4, 34816, 5120, 17408, 1801U, ActivationCompute::A16},

--- a/tests/ops/test_attn_input_proj.cpp
+++ b/tests/ops/test_attn_input_proj.cpp
@@ -305,6 +305,8 @@ int run_nvfp4_target() {
     for (const std::int32_t tokens : {1, 2, 4, 8, 16, 20, 32, 33}) {
         failures += run_nvfp4_target_case(parent, tokens);
     }
+    failures += run_nvfp4_target_case(parent, 1, ops::LinearPolicy::AllowA4);
+    failures += run_nvfp4_target_case(parent, 2, ops::LinearPolicy::AllowA4);
     failures += run_nvfp4_target_case(parent, 4, ops::LinearPolicy::AllowA4);
     failures += run_nvfp4_target_case(parent, 17, ops::LinearPolicy::AllowA4);
     failures += run_nvfp4_target_case(parent, 1024, ops::LinearPolicy::AllowA4);

--- a/tests/ops/test_gdn_input_proj_conv_snapshot.cpp
+++ b/tests/ops/test_gdn_input_proj_conv_snapshot.cpp
@@ -738,7 +738,7 @@ int run_nvfp4_case(DevicePackedWeight& parent, std::int32_t tokens, ops::LinearP
                 parent.host, row, activation.data() + static_cast<std::size_t>(token) * kHidden,
                 kHidden);
         });
-    const bool a4 = policy == ops::LinearPolicy::AllowA4 && tokens >= 4;
+    const bool a4 = policy == ops::LinearPolicy::AllowA4;
     const ReductionCriterion& criterion =
         a4 ? kGdnInputProjConvSnapshotA4Tolerance : kGdnInputProjConvSnapshotA16Tolerance;
     const std::string suffix =
@@ -1012,16 +1012,18 @@ int main() {
         std::cerr << "W8 snapshot interval did not preserve its zero/nonzero route boundary\n";
         ++failures;
     }
+    const std::size_t nvfp4_a4_1 = ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
+        QType::NVFP4, 16384, 5120, ops::LinearPolicy::AllowA4, 1, 1, 1);
     const std::size_t nvfp4_a4_4 = ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
         QType::NVFP4, 16384, 5120, ops::LinearPolicy::AllowA4, 1, 4, 4);
     if (ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
             QType::NVFP4, 16384, 5120, ops::LinearPolicy::A16Only, 1, 1, 16) != 0 ||
         ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
-            QType::NVFP4, 16384, 5120, ops::LinearPolicy::AllowA4, 1, 1, 3) != 0 ||
-        nvfp4_a4_4 == 0 ||
+            QType::NVFP4, 16384, 5120, ops::LinearPolicy::AllowA4, 1, 1, 3) == 0 ||
+        nvfp4_a4_1 == 0 || nvfp4_a4_4 == 0 || nvfp4_a4_1 >= nvfp4_a4_4 ||
         ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
             QType::NVFP4, 16384, 5120, ops::LinearPolicy::AllowA4, 1, 1, 4) != nvfp4_a4_4) {
-        std::cerr << "NVFP4 snapshot interval did not preserve its A16/A4 route boundary\n";
+        std::cerr << "NVFP4 snapshot workspace did not preserve its A16/A4 policy routes\n";
         ++failures;
     }
     const auto fp8_snapshot_capacity = [](ops::LinearPolicy policy, std::int32_t batch,

--- a/tests/targets/qwen3_6_27b/test_engine_mtp_greedy_parity_real.cpp
+++ b/tests/targets/qwen3_6_27b/test_engine_mtp_greedy_parity_real.cpp
@@ -1,0 +1,122 @@
+#include "ninfer/engine.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr std::uint32_t kOutputTokens = 128;
+constexpr std::array<std::uint32_t, 5> kMtpDraftCounts{1, 2, 3, 4, 5};
+
+struct KvProfile {
+    std::string_view name;
+    ninfer::KvCacheStorage storage;
+};
+
+constexpr std::array kKvProfiles{
+    KvProfile{"bf16", ninfer::KvCacheStorage::BFloat16},
+    KvProfile{"int8", ninfer::KvCacheStorage::Int8Group64},
+};
+
+ninfer::EngineOptions engine_options(const char* artifact, ninfer::KvCacheStorage kv_storage,
+                                     std::uint32_t mtp_draft_tokens) {
+    const bool mtp = mtp_draft_tokens != 0;
+    ninfer::EngineOptions options;
+    options.artifact_path        = artifact;
+    options.max_context          = 512;
+    options.kv_capacity          = ninfer::KvCapacityPolicy::explicit_capacity(512);
+    options.max_concurrency      = 1;
+    options.prefill_chunk        = 128;
+    options.kv_cache             = kv_storage;
+    options.use_cuda_graph       = false;
+    options.speculative.backend  = mtp ? ninfer::SpeculativeBackend::Mtp
+                                       : ninfer::SpeculativeBackend::None;
+    options.speculative.draft_tokens = mtp_draft_tokens;
+    options.speculative.proposal_head =
+        mtp ? ninfer::ProposalHead::Optimized : ninfer::ProposalHead::Full;
+    return options;
+}
+
+ninfer::PromptInput prompt() {
+    ninfer::ChatMessage message;
+    message.role = ninfer::ChatRole::User;
+    message.parts.push_back(ninfer::MessagePart{
+        .kind  = ninfer::MessagePartKind::Text,
+        .text  = "Write snake in Python, but in a code block. Do not use tools.",
+        .media = {},
+    });
+    ninfer::PromptInput input;
+    input.messages.push_back(std::move(message));
+    input.options.enable_thinking = true;
+    return input;
+}
+
+std::vector<ninfer::TokenId> generate(const char* artifact, ninfer::KvCacheStorage kv_storage,
+                                       std::uint32_t mtp_draft_tokens) {
+    const std::string route = mtp_draft_tokens == 0
+                                  ? "ordinary"
+                                  : "MTP k=" + std::to_string(mtp_draft_tokens);
+    try {
+        ninfer::Engine engine(engine_options(artifact, kv_storage, mtp_draft_tokens));
+        ninfer::RequestOptions request;
+        request.execution.requested_output_tokens = kOutputTokens;
+        request.execution.sampling.temperature    = 0.0F;
+        request.execution.sampling.seed           = 424242;
+        request.execution.allow_prefix_reuse      = false;
+        request.stop.include_model_defaults       = false;
+        ninfer::GenerationResult result = engine.generate(engine.prepare(prompt()), request);
+        if (result.generated_token_ids.size() != kOutputTokens ||
+            result.finish_reason != ninfer::FinishReason::OutputLimit) {
+            throw std::runtime_error("did not reach its fixed output limit");
+        }
+        return result.generated_token_ids;
+    } catch (const std::exception& error) {
+        throw std::runtime_error(route + ": " + error.what());
+    }
+}
+
+} // namespace
+
+int main() {
+    const char* artifact = std::getenv("NINFER_MTP_GREEDY_PARITY_WEIGHTS");
+    if (artifact == nullptr || *artifact == '\0') {
+        std::cout << "skip: NINFER_MTP_GREEDY_PARITY_WEIGHTS is not set\n";
+        return 77;
+    }
+
+    try {
+        for (const KvProfile profile : kKvProfiles) {
+            const std::vector<ninfer::TokenId> ordinary =
+                generate(artifact, profile.storage, 0);
+            for (const std::uint32_t draft_tokens : kMtpDraftCounts) {
+                const std::vector<ninfer::TokenId> mtp =
+                    generate(artifact, profile.storage, draft_tokens);
+                const auto [ordinary_mismatch, mtp_mismatch] =
+                    std::mismatch(ordinary.begin(), ordinary.end(), mtp.begin(), mtp.end());
+                if (ordinary_mismatch != ordinary.end()) {
+                    const std::size_t index =
+                        static_cast<std::size_t>(ordinary_mismatch - ordinary.begin());
+                    std::cerr << "greedy MTP parity mismatch for " << profile.name << " KV at k="
+                              << draft_tokens << ", generated token " << index
+                              << ": ordinary=" << *ordinary_mismatch
+                              << " mtp=" << *mtp_mismatch << '\n';
+                    return 1;
+                }
+            }
+        }
+    } catch (const std::exception& error) {
+        std::cerr << "greedy MTP parity test failed: " << error.what() << '\n';
+        return 1;
+    }
+
+    std::cout << "ok\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- align BF16 and NVFP4 attention, GDN, residual, and MLP projection routes so decode and speculative verification use width-invariant arithmetic
- evaluate BF16 GQA as canonical query columns and preserve INT8 split partials in FP32 while routing verification columns through decode arithmetic
- add route-level coverage and a real-artifact regression that compares MTP-off with draft counts 1 through 5 for both BF16 and INT8 KV
- document exact greedy committed-token parity and distinguish it from stochastic distributional equivalence

## Verification

- `/home/mirko/.local/share/mamba/envs/ninfer/bin/cmake --build build -j`
- `NINFER_MTP_GREEDY_PARITY_WEIGHTS=models/qwen3_8_27b_nvfp4_ostfralla.ninfer ./build/tests/ninfer_qwen3_6_27b_mtp_greedy_parity_real_test` (`ok`)
- affected GQA, GDN input/snapshot/record, attention projection, LinearAdd, Linear, and SwiGLU operator tests pass
- `git diff --check`

## Known unrelated test failure

An unrelated `ninfer_gdn_gating_proj_test` T=1024 gross-error criterion failure was observed on the unchanged Split8 route. The changed T=1 route completes without an additional failure.