### PR TITLE
chore(git): ignore local development directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,10 @@ tools/freq_corpus/fixtures/*
 profiles/
 .chatgpt/
 
+# Local development directories
+models/
+scripts/
+worktrees/
+
 # Claude Code personal/local settings (may contain API tokens)
 .claude/settings.local.json


### PR DESCRIPTION
## Summary

- ignore root-level `models/`, `scripts/`, and `worktrees/` directories
- keep machine-local development assets out of repository status

## Verification

- `git diff --check`
- `git check-ignore -v --no-index models/ scripts/ worktrees/`