### PR TITLE
feat(nvfp4): support Qwen3.8 QUASAR artifacts

### DIFF
--- a/docs/maintainer/qwen3.8-27b-artifact.md
+++ b/docs/maintainer/qwen3.8-27b-artifact.md
@@ -2,8 +2,9 @@
 
 This reference defines the `qwen3.8-27b/nvfp4` `.ninfer` storage contract: identity, object
 inventory, shapes, numeric formats, storage layouts, fused row order, aliases, fixed sources, and
-source-to-object transforms. The existing registered `qwen3.8-27b/groupwise-int` contract remains
-defined in Section 13.
+source-to-object transforms. Section 13 defines the descriptor-selected QUASAR profile, Section 14
+retains the published legacy W8-endpoint artifact, and Section 15 defines the existing registered
+`qwen3.8-27b/groupwise-int` contract.
 
 The NVFP4 profile is a registered Engine identity implemented by the target converter, exact
 binder, and Qwen3.8 execution leaves. The generic artifact registry resolves its version-2
@@ -706,7 +707,66 @@ Validation must reject an incomplete or alternate mixed-precision allocation. It
 missing source matrix from the official BF16 checkpoint, silently requantize a preserved FP8 or
 NVFP4 field, or add unused source calibration fields as artifact objects.
 
-## 13. Legacy W8-endpoint NVFP4 compatibility artifact
+## 13. QUASAR all-linear NVFP4 source profile
+
+The converter also accepts
+[`QUASAR-QAT/Qwen3.8-27B-QUASAR-NVFP4`](https://huggingface.co/QUASAR-QAT/Qwen3.8-27B-QUASAR-NVFP4)
+revision `d8e6fbfa3e3a78899b440222b827430045a05b44`. A synchronized downstream copy is maintained at
+[`MirkoCovizzi/Qwen3.8-27B-QUASAR-NVFP4`](https://huggingface.co/MirkoCovizzi/Qwen3.8-27B-QUASAR-NVFP4).
+The standard entry point detects the source's exact single-group `nvfp4-pack-quantized`
+configuration; the fixed Unsloth mixed source remains governed by Sections 3 through 12 and follows
+its existing path unchanged.
+
+The QUASAR source stores all 496 Text `Linear` modules as NVFP4. NInfer preserves the packed codes,
+natural E4M3FN scales, weight divisors, and input divisors for the 400 execution-supported source
+matrices. Consumer-boundary fusion produces 256 NVFP4 parents: 32 full-attention parents, 96 GDN
+input/output parents, and 128 MLP parents. Every fused source group must already have bit-identical
+weight and input divisor words; the converter does not reconcile or requantize a mismatched group.
+
+The 96 GDN `in_proj_a` and `in_proj_b` matrices have output extent 48 and cannot use the registered
+NVFP4 execution route. For each source matrix, the converter evaluates the registered represented
+weight formula
+
+```text
+W[n,k] = decode_e2m1(c[n,k]) * decode_e4m3fn(s[n,floor(k/16)]) / d_w
+```
+
+in binary32, rounds each result to BF16, and concatenates A then B into the existing
+`gdn/a_b_projection [96,5120]` parent. This explicit source-to-artifact cast is the only QUASAR Text
+matrix conversion; it does not substitute the official pre-QAT A/B values.
+
+The two vocabulary endpoints use `W8G32_F16S`. The QUASAR revision contains the complete 15-tensor
+BF16 MTP source module; its twelve artifact objects use the Section 12.1 transforms and are sourced
+from QUASAR. Draft head, Vision, vocabulary endpoints, and frontend resources continue to come from
+the fixed official source in Section 10.1. The complete profile has 1,268 objects: 1,262 tensors and
+six resources. Its numeric counts are:
+
+| Format | Tensors |
+|---|---:|
+| `BF16` | 534 |
+| `FP32` | 352 |
+| `I32` | 1 |
+| `Q4G64_F16S` | 55 |
+| `Q5G64_F16S` | 54 |
+| `Q6G64_F16S` | 1 |
+| `W8G32_F16S` | 9 |
+| `NVFP4` | 256 |
+
+The runtime selects `Qwen38Nvfp4Quasar` when both vocabulary endpoints are W8 and
+`text/layers/3/attention/query_key_gate_value` is NVFP4. This descriptor separates it from the
+legacy W8 profile without changing the public `qwen3.8-27b/nvfp4` identity.
+
+The canonical conversion command is:
+
+```bash
+python3 -m tools.convert.qwen3_8_27b.convert_nvfp4 \
+  --model /path/to/Qwen3.8-27B \
+  --quantized-model /path/to/Qwen3.8-27B-QUASAR-NVFP4 \
+  --out out/qwen3_8_27b_nvfp4.ninfer \
+  --device cuda
+```
+
+## 14. Legacy W8-endpoint NVFP4 compatibility artifact
 
 NInfer also accepts the externally published Qwen3.8 NVFP4 artifact whose endpoint tensors use the
 older Qwen3.6-style storage profile. It retains the same artifact identity but is selected as the
@@ -724,7 +784,7 @@ The accepted artifact has 1307 objects, 1301 tensors, 6 frontend resources, and 
 The current Qwen3.8 NVFP4 profile remains the separate FP8-endpoint mixed allocation in Section 3.
 An artifact with mixed, missing, or unknown endpoint descriptors is rejected rather than guessed.
 
-## 14. Existing `groupwise-int` artifact
+## 15. Existing `groupwise-int` artifact
 
 The existing registered peer artifact retains this identity:
 

--- a/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
+++ b/src/targets/qwen3_6_27b/export/ninfer/targets/qwen3_6_27b/package.h
@@ -35,6 +35,7 @@ enum class WeightsProfile : std::uint8_t {
     Qwen36Nvfp4,
     Qwen38Nvfp4,
     Qwen38Nvfp4LegacyW8,
+    Qwen38Nvfp4Quasar,
 };
 
 using Frontend        = qwen3_6::Frontend;

--- a/src/targets/qwen3_6_27b/impl/load/bindings.cpp
+++ b/src/targets/qwen3_6_27b/impl/load/bindings.cpp
@@ -42,6 +42,7 @@ NumericFormat endpoint_format(WeightsProfile weights_profile) {
     case WeightsProfile::Qwen38Nvfp4:
         return NumericFormat::FP8_E4M3FN_ROW_BF16S;
     case WeightsProfile::Qwen38Nvfp4LegacyW8:
+    case WeightsProfile::Qwen38Nvfp4Quasar:
         return NumericFormat::W8G32_F16S;
     }
     throw std::invalid_argument("qwen3_6_27b: invalid weights profile");
@@ -268,7 +269,7 @@ void bind_groupwise_text_layers(artifact::Binder& binder, BindingPlan& out) {
     }
 }
 
-void bind_nvfp4_text_layers(artifact::Binder& binder, BindingPlan& out) {
+void bind_nvfp4_text_layers(artifact::Binder& binder, BindingPlan& out, bool full_nvfp4) {
     for (std::size_t layer = 0; layer < kTextLayers; ++layer) {
         TextLayerPlan& target    = out.text_layers[layer];
         const std::string prefix = "text/layers/" + std::to_string(layer) + "/";
@@ -277,7 +278,7 @@ void bind_nvfp4_text_layers(artifact::Binder& binder, BindingPlan& out) {
         target.is_full_attention = is_full_layer(layer);
         if (target.is_full_attention) {
             WeightPlan input;
-            if (is_early_attention_input(layer)) {
+            if (!full_nvfp4 && is_early_attention_input(layer)) {
                 input = bind_weight(binder, prefix + "attention/query_key_gate_value",
                                     NumericFormat::BF16, {14336, 5120});
             } else {
@@ -291,7 +292,7 @@ void bind_nvfp4_text_layers(artifact::Binder& binder, BindingPlan& out) {
                 binder, prefix + "attention/query_norm", NumericFormat::BF16, {256});
             target.attention.key_norm = artifact::bind_device_tensor(
                 binder, prefix + "attention/key_norm", NumericFormat::BF16, {256});
-            if (is_bf16_attention_output(layer)) {
+            if (!full_nvfp4 && is_bf16_attention_output(layer)) {
                 target.attention.output = bind_weight(binder, prefix + "attention/output",
                                                       NumericFormat::BF16, {5120, 6144});
             } else {
@@ -306,12 +307,19 @@ void bind_nvfp4_text_layers(artifact::Binder& binder, BindingPlan& out) {
                                                                   NumericFormat::FP32, {48});
             target.gdn.convolution = artifact::bind_device_tensor(
                 binder, prefix + "gdn/convolution", NumericFormat::BF16, {4, 10240});
-            target.gdn.control_projection = SplitGdnControlProjectionPlan{
-                .a_projection = bind_weight(binder, prefix + "gdn/a_projection",
-                                            NumericFormat::BF16, {48, 5120}),
-                .b_projection = bind_weight(binder, prefix + "gdn/b_projection",
-                                            NumericFormat::BF16, {48, 5120}),
-            };
+            if (full_nvfp4) {
+                target.gdn.control_projection = FusedGdnControlProjectionPlan{
+                    .a_b_projection = bind_weight(binder, prefix + "gdn/a_b_projection",
+                                                  NumericFormat::BF16, {96, 5120}),
+                };
+            } else {
+                target.gdn.control_projection = SplitGdnControlProjectionPlan{
+                    .a_projection = bind_weight(binder, prefix + "gdn/a_projection",
+                                                NumericFormat::BF16, {48, 5120}),
+                    .b_projection = bind_weight(binder, prefix + "gdn/b_projection",
+                                                NumericFormat::BF16, {48, 5120}),
+                };
+            }
             target.gdn.input_projection = FusedGdnInputProjectionPlan{
                 .query_key_value_z =
                     bind_nvfp4_weight(binder, prefix + "gdn/query_key_value_z", 16384, 5120,
@@ -319,7 +327,7 @@ void bind_nvfp4_text_layers(artifact::Binder& binder, BindingPlan& out) {
             };
             target.gdn.norm = artifact::bind_device_tensor(binder, prefix + "gdn/norm",
                                                            NumericFormat::BF16, {128});
-            if (is_bf16_gdn_output(layer)) {
+            if (!full_nvfp4 && is_bf16_gdn_output(layer)) {
                 target.gdn.output =
                     bind_weight(binder, prefix + "gdn/output", NumericFormat::BF16, {5120, 6144});
             } else {
@@ -428,13 +436,16 @@ ArtifactLoadPlan bind_artifact(artifact::Binder& binder, WeightsProfile weights_
         bind_groupwise_text_layers(binder, out);
         break;
     case WeightsProfile::Qwen36Nvfp4:
-        bind_nvfp4_text_layers(binder, out);
+        bind_nvfp4_text_layers(binder, out, false);
         break;
     case WeightsProfile::Qwen38Nvfp4:
         bind_qwen38_nvfp4_text_layers(binder, out);
         break;
     case WeightsProfile::Qwen38Nvfp4LegacyW8:
-        bind_nvfp4_text_layers(binder, out);
+        bind_nvfp4_text_layers(binder, out, false);
+        break;
+    case WeightsProfile::Qwen38Nvfp4Quasar:
+        bind_nvfp4_text_layers(binder, out, true);
         break;
     default:
         throw std::invalid_argument("qwen3_6_27b: invalid weights profile");

--- a/src/targets/qwen3_6_27b/impl/package.cpp
+++ b/src/targets/qwen3_6_27b/impl/package.cpp
@@ -84,13 +84,19 @@ ModelSamplingDefaults Package::sampling_defaults(std::string_view model) {
                              std::string(target_key) + "'");
 }
 
-bool endpoint_matches(const artifact::Reader& reader, std::string_view name,
-                      artifact::NumericFormat format, artifact::StorageLayout layout) {
+bool tensor_matches(const artifact::Reader& reader, std::string_view name,
+                    artifact::NumericFormat format, artifact::StorageLayout layout,
+                    std::vector<std::uint64_t> shape) {
     const auto* object = reader.find(name);
     if (object == nullptr) { return false; }
     const auto* tensor = std::get_if<artifact::TensorDescriptor>(object);
     return tensor != nullptr && tensor->format == format && tensor->layout == layout &&
-           tensor->shape == std::vector<std::uint64_t>{248320, 5120};
+           tensor->shape == shape;
+}
+
+bool endpoint_matches(const artifact::Reader& reader, std::string_view name,
+                      artifact::NumericFormat format, artifact::StorageLayout layout) {
+    return tensor_matches(reader, name, format, layout, {248320, 5120});
 }
 
 Package::WeightsProfile Package::resolve_weights(const artifact::Reader& reader) {
@@ -116,7 +122,13 @@ Package::WeightsProfile Package::resolve_weights(const artifact::Reader& reader)
                                  endpoint_matches(reader, "text/output_head",
                                                   artifact::NumericFormat::FP8_E4M3FN_ROW_BF16S,
                                                   artifact::StorageLayout::RowScaleV1);
-        if (legacy_w8) { return WeightsProfile::Qwen38Nvfp4LegacyW8; }
+        if (legacy_w8) {
+            const bool quasar =
+                tensor_matches(reader, "text/layers/3/attention/query_key_gate_value",
+                               artifact::NumericFormat::NVFP4,
+                               artifact::StorageLayout::BlockScaleK16M128x4V1, {14336, 5120});
+            return quasar ? WeightsProfile::Qwen38Nvfp4Quasar : WeightsProfile::Qwen38Nvfp4LegacyW8;
+        }
         if (current_fp8) { return WeightsProfile::Qwen38Nvfp4; }
         throw std::runtime_error("unsupported qwen3.8-27b/nvfp4 endpoint storage profile");
     }

--- a/src/targets/qwen3_6_27b/impl/variant.cpp
+++ b/src/targets/qwen3_6_27b/impl/variant.cpp
@@ -347,6 +347,7 @@ std::size_t Variant::attention_projection_workspace_capacity_bytes(WeightsProfil
         return 0;
     case WeightsProfile::Qwen36Nvfp4:
     case WeightsProfile::Qwen38Nvfp4LegacyW8:
+    case WeightsProfile::Qwen38Nvfp4Quasar:
         return ops::attn_input_proj_workspace_capacity_bytes(
             QType::NVFP4, 14336, TextConfig::hidden, kNvfp4TextPolicy, first, last);
     case WeightsProfile::Qwen38Nvfp4:
@@ -367,6 +368,7 @@ std::size_t Variant::attention_output_projection_workspace_capacity_bytes(
                                                         ops::LinearPolicy::A16Only, first, last);
     case WeightsProfile::Qwen36Nvfp4:
     case WeightsProfile::Qwen38Nvfp4LegacyW8:
+    case WeightsProfile::Qwen38Nvfp4Quasar:
         return ops::linear_add_workspace_capacity_bytes(QType::NVFP4, TextConfig::hidden,
                                                         TextConfig::query_size, kNvfp4TextPolicy,
                                                         first, last);
@@ -389,6 +391,7 @@ std::size_t Variant::gdn_input_projection_workspace_capacity_bytes(WeightsProfil
         return 0;
     case WeightsProfile::Qwen36Nvfp4:
     case WeightsProfile::Qwen38Nvfp4LegacyW8:
+    case WeightsProfile::Qwen38Nvfp4Quasar:
         return ops::gdn_input_proj_workspace_capacity_bytes(QType::NVFP4, 16384, TextConfig::hidden,
                                                             kNvfp4TextPolicy, first, last);
     case WeightsProfile::Qwen38Nvfp4:
@@ -411,6 +414,7 @@ std::size_t Variant::gdn_input_projection_snapshot_workspace_capacity_bytes(
                             batch_size, first, last));
     case WeightsProfile::Qwen36Nvfp4:
     case WeightsProfile::Qwen38Nvfp4LegacyW8:
+    case WeightsProfile::Qwen38Nvfp4Quasar:
         return std::max(kMinimumLeafWorkspaceBytes,
                         ops::gdn_input_proj_conv_snapshot_workspace_capacity_bytes(
                             QType::NVFP4, 16384, TextConfig::hidden, kNvfp4TextPolicy, batch_size,
@@ -437,6 +441,7 @@ std::size_t Variant::gdn_input_projection_record_workspace_capacity_bytes(
                             batch_size, first, last));
     case WeightsProfile::Qwen36Nvfp4:
     case WeightsProfile::Qwen38Nvfp4LegacyW8:
+    case WeightsProfile::Qwen38Nvfp4Quasar:
         return std::max(kMinimumLeafWorkspaceBytes,
                         ops::gdn_input_proj_conv_record_workspace_capacity_bytes(
                             QType::NVFP4, 16384, TextConfig::hidden, kNvfp4TextPolicy, batch_size,
@@ -463,6 +468,7 @@ std::size_t Variant::gdn_output_projection_workspace_capacity_bytes(WeightsProfi
                                                         ops::LinearPolicy::A16Only, first, last);
     case WeightsProfile::Qwen36Nvfp4:
     case WeightsProfile::Qwen38Nvfp4LegacyW8:
+    case WeightsProfile::Qwen38Nvfp4Quasar:
         return ops::linear_add_workspace_capacity_bytes(
             QType::NVFP4, TextConfig::hidden, TextConfig::value_dim, kNvfp4TextPolicy, first, last);
     case WeightsProfile::Qwen38Nvfp4:
@@ -490,6 +496,7 @@ std::size_t Variant::post_mixer_workspace_capacity_bytes(WeightsProfile weights_
                                           ops::LinearPolicy::A16Only, first, last);
     case WeightsProfile::Qwen36Nvfp4:
     case WeightsProfile::Qwen38Nvfp4LegacyW8:
+    case WeightsProfile::Qwen38Nvfp4Quasar:
         return post_mixer_workspace_bytes(QType::NVFP4, QType::NVFP4, kNvfp4TextPolicy, first,
                                           last);
     case WeightsProfile::Qwen38Nvfp4: {

--- a/tests/targets/qwen3_6_27b/test_load_plan.cpp
+++ b/tests/targets/qwen3_6_27b/test_load_plan.cpp
@@ -185,6 +185,55 @@ int verify_qwen38_modern(const std::filesystem::path& path) {
     return 0;
 }
 
+int verify_qwen38_quasar(const std::filesystem::path& path) {
+    ninfer::artifact::Reader reader(path);
+    if (Package::resolve_weights(reader) != WeightsProfile::Qwen38Nvfp4Quasar) {
+        std::cerr << "QUASAR Qwen3.8 NVFP4 resolved to the wrong profile\n";
+        return 1;
+    }
+    ninfer::artifact::Binder binder(reader);
+    const ArtifactLoadPlan plan =
+        bind_artifact(binder, WeightsProfile::Qwen38Nvfp4Quasar, all_features());
+    if (plan.materialization.object_count != 1268 ||
+        plan.materialization.device_objects.size() != 1006 ||
+        plan.materialization.host_objects.size() != 6) {
+        std::cerr << "QUASAR materialization plan is incomplete\n";
+        return 1;
+    }
+    std::size_t nvfp4_weights = 0;
+    const auto check_weight   = [&](const WeightPlan& weight) {
+        if (!valid_divisors(weight)) { return false; }
+        ++nvfp4_weights;
+        return true;
+    };
+    for (const TextLayerPlan& layer : plan.bindings.text_layers) {
+        if (!check_weight(layer.mlp.gate_up) || !check_weight(layer.mlp.down)) { return 1; }
+        if (layer.is_full_attention) {
+            const auto* fused =
+                std::get_if<FusedAttentionProjectionPlan>(&layer.attention.projection);
+            if (fused == nullptr || !check_weight(fused->query_key_gate_value) ||
+                !check_weight(layer.attention.output)) {
+                return 1;
+            }
+        } else {
+            const auto* input =
+                std::get_if<FusedGdnInputProjectionPlan>(&layer.gdn.input_projection);
+            const auto* control =
+                std::get_if<FusedGdnControlProjectionPlan>(&layer.gdn.control_projection);
+            if (input == nullptr || control == nullptr ||
+                control->a_b_projection.format != NumericFormat::BF16 ||
+                !check_weight(input->query_key_value_z) || !check_weight(layer.gdn.output)) {
+                return 1;
+            }
+        }
+    }
+    if (nvfp4_weights != 256) {
+        std::cerr << "QUASAR Text inventory has " << nvfp4_weights << " NVFP4 parents\n";
+        return 1;
+    }
+    return 0;
+}
+
 int verify_profile_mismatch_rejection() {
     ninfer::DeviceContext device(0);
     ninfer::EngineOptions options;
@@ -254,6 +303,8 @@ int main() {
         "NINFER_QWEN3_8_27B_LEGACY_NVFP4_WEIGHTS", "qwen3_8_27b_nvfp4_ostfralla.ninfer");
     const std::filesystem::path qwen38_modern =
         artifact_path("NINFER_QWEN3_8_27B_NVFP4_WEIGHTS", "qwen3_8_27b_nvfp4.ninfer");
+    const std::filesystem::path qwen38_quasar =
+        artifact_path("NINFER_QWEN3_8_27B_QUASAR_NVFP4_WEIGHTS", "qwen3_8_27b_quasar_nvfp4.ninfer");
     bool ran = false;
     if (const int result = verify_profile_mismatch_rejection(); result != 0) { return result; }
     if (std::filesystem::is_regular_file(groupwise) && std::filesystem::is_regular_file(nvfp4)) {
@@ -276,6 +327,10 @@ int main() {
     if (std::filesystem::is_regular_file(qwen38_modern)) {
         ran = true;
         if (const int result = verify_qwen38_modern(qwen38_modern); result != 0) { return result; }
+    }
+    if (std::filesystem::is_regular_file(qwen38_quasar)) {
+        ran = true;
+        if (const int result = verify_qwen38_quasar(qwen38_quasar); result != 0) { return result; }
     }
     if (!ran) {
         std::cerr << "skip: no real 27B artifacts available for load-plan validation\n";

--- a/tests/targets/qwen3_8_27b/test_quasar_nvfp4_converter.py
+++ b/tests/targets/qwen3_8_27b/test_quasar_nvfp4_converter.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+
+import torch
+
+from tools.convert.qwen3_8_27b import convert_nvfp4
+from tools.convert.qwen3_8_27b import convert_nvfp4_quasar as converter
+from tools.convert.qwen3_8_27b import inventory_nvfp4_quasar as inventory
+from tools.convert.qwen3_8_27b import recipe_nvfp4_quasar as recipe
+
+
+def _quasar_config() -> dict[str, object]:
+    common = {
+        "num_bits": 4,
+        "type": "float",
+        "strategy": "tensor_group",
+        "group_size": 16,
+        "symmetric": True,
+        "scale_dtype": "torch.float8_e4m3fn",
+    }
+    return {
+        "quantization_config": {
+            "format": "nvfp4-pack-quantized",
+            "config_groups": {
+                "group_0": {
+                    "format": "nvfp4-pack-quantized",
+                    "targets": ["Linear"],
+                    "weights": {**common, "dynamic": False},
+                    "input_activations": {**common, "dynamic": "local"},
+                }
+            },
+        }
+    }
+
+
+def test_quasar_inventory_and_closed_source_allocation() -> None:
+    assert len(inventory.OBJECT_SPECS) == 1268
+    assert len(inventory.TENSOR_SPECS) == 1262
+    assert inventory.FORMAT_COUNTS == {
+        "BF16": 534,
+        "FP32": 352,
+        "I32": 1,
+        "Q4G64_F16S": 55,
+        "Q5G64_F16S": 54,
+        "Q6G64_F16S": 1,
+        "W8G32_F16S": 9,
+        "NVFP4": 256,
+        "FP8_E4M3FN_ROW_BF16S": 0,
+    }
+    assert (
+        len(recipe.NVFP4_SOURCES),
+        len(recipe.CONTROL_SOURCES),
+        len(recipe.ALL_NVFP4_SOURCES),
+        len(recipe.SOURCE_REQUIREMENTS),
+    ) == (400, 96, 496, 2352)
+    assert recipe.QUANTIZED_REVISION == (
+        "d8e6fbfa3e3a78899b440222b827430045a05b44"
+    )
+    assert tuple(recipe.QUANTIZED_MTP_BY_NAME) == tuple(
+        spec.name for spec in inventory.MTP_TENSOR_SPECS
+    )
+    assert not set(recipe.QUANTIZED_MTP_BY_NAME).intersection(
+        recipe.OFFICIAL_RECIPES_BY_NAME
+    )
+    assert "mtp.fc.weight" in recipe.SOURCE_REQUIREMENTS
+    assert "mtp.norm.weight" in recipe.SOURCE_REQUIREMENTS
+
+
+def test_standard_entry_point_dispatches_quasar_profile(tmp_path, monkeypatch) -> None:
+    quantized = tmp_path / "quantized"
+    quantized.mkdir()
+    (quantized / "config.json").write_text(json.dumps(_quasar_config()))
+    expected = tmp_path / "report.json"
+
+    def fake_convert(*args, **kwargs):
+        return expected
+
+    monkeypatch.setattr(converter, "convert", fake_convert)
+    result = convert_nvfp4.convert(
+        tmp_path / "official",
+        quantized,
+        tmp_path / "qwen3_8_27b_nvfp4.ninfer",
+        device="cpu",
+    )
+    assert result == expected
+
+
+def test_control_decode_uses_exact_nvfp4_words_before_bf16_cast() -> None:
+    source = recipe.MatrixSource("control", (1, 16))
+    scale = torch.tensor([[0x38]], dtype=torch.uint8).view(torch.float8_e4m3fn)
+    tensors = {
+        "control.weight_packed": torch.full((1, 8), 0x21, dtype=torch.uint8),
+        "control.weight_scale": scale,
+        "control.weight_global_scale": torch.tensor([2.0], dtype=torch.float32),
+    }
+
+    class Reader:
+        def get(self, name: str) -> torch.Tensor:
+            return tensors[name]
+
+    decoded = recipe._decode_nvfp4_source(source, Reader())
+    expected = torch.tensor(
+        [[0.25, 0.5] * 8], dtype=torch.bfloat16
+    )
+    assert torch.equal(decoded, expected)

--- a/tools/README.md
+++ b/tools/README.md
@@ -38,6 +38,12 @@ python3 -m tools.convert.qwen3_8_27b.convert \
   --model /path/to/Qwen3.8-27B \
   --out out/qwen3_8_27b.ninfer
 
+python3 -m tools.convert.qwen3_8_27b.convert_nvfp4 \
+  --model /path/to/Qwen3.8-27B \
+  --quantized-model /path/to/Qwen3.8-27B-NVFP4 \
+  --out out/qwen3_8_27b_nvfp4.ninfer \
+  --device cuda
+
 python3 -m tools.convert.qwen3_6_35b_a3b.convert \
   --model /path/to/Qwen3.6-35B-A3B-base \
   --dflash-model /path/to/Qwen3.6-35B-A3B-DFlash \

--- a/tools/convert/qwen3_8_27b/convert_nvfp4_quasar.py
+++ b/tools/convert/qwen3_8_27b/convert_nvfp4_quasar.py
@@ -1,12 +1,4 @@
-"""Build the registered Qwen3.8-27B NVFP4 artifact from its two source roles.
-
-Canonical invocation::
-
-    python3 -m tools.convert.qwen3_8_27b.convert_nvfp4 \
-      --model /path/to/Qwen3.8-27B/base-hf-bf16 \
-      --quantized-model /path/to/Qwen3.8-27B/vllm-nvfp4-fp8 \
-      --out out/qwen3_8_27b_nvfp4.ninfer
-"""
+"""Build the registered Qwen3.8-27B NVFP4 artifact from a QUASAR source."""
 
 from __future__ import annotations
 
@@ -24,11 +16,7 @@ from tools.artifact.container import (
     ArtifactObject,
     ArtifactWriter,
 )
-from tools.artifact.layouts import (
-    encode_direct,
-    encode_fp8_row_scaled,
-    encode_nvfp4,
-)
+from tools.artifact.layouts import encode_direct, encode_nvfp4
 from tools.convert.common.quantize import pick_device
 from tools.convert.common.safetensors import ShardReader
 from tools.convert.qwen3_6.common import conversion as family_conversion
@@ -37,21 +25,22 @@ from tools.convert.qwen3_6_27b import convert as family_config
 from tools.convert.qwen3_6_27b import draft_head
 
 from . import convert as base_convert
-from . import fp8_embedding
-from . import inventory_nvfp4 as inventory
-from . import recipe_nvfp4 as recipe
+from . import convert_nvfp4 as mixed_converter
+from . import inventory_nvfp4_quasar as inventory
+from . import recipe_nvfp4_quasar as recipe
 
 
-RECIPE_ID = "qwen3_8_27b_nvfp4-v1"
+RECIPE_ID = "qwen3_8_27b_quasar_nvfp4-v2"
 OUTPUT_BASENAME = "qwen3_8_27b_nvfp4.ninfer"
 
-_FP8_TARGETS = [
-    r"re:.*self_attn\.(q|k|v|o)_proj$",
-    r"re:.*linear_attn\.(in_proj_qkv|in_proj_z|out_proj)$",
-    r"re:.*lm_head",
-    r"re:.*layers\.(56|57|58|59|60|61|62|63)\.mlp\.(gate|up|down)_proj$",
+_IGNORED_TARGETS = [
+    "lm_head",
+    "re:.*visual.*",
+    "re:.*mtp.*",
+    "re:.*embed_vision.*",
+    "re:.*embed_audio.*",
+    "re:.*vision_embedder.*",
 ]
-_NVFP4_TARGETS = [r"re:.*mlp\.(gate|up|down)_proj$"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,88 +59,19 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
-def _validate_index(model_dir: Path) -> None:
-    index_path = model_dir / "model.safetensors.index.json"
-    value = family_conversion.load_json(index_path)
-    weight_map = value.get("weight_map")
-    if not isinstance(weight_map, dict) or not weight_map:
-        raise ValueError(f"{index_path}: weight_map must be a nonempty object")
-    if any(
-        not isinstance(name, str)
-        or not name
-        or not isinstance(shard, str)
-        or not shard
-        for name, shard in weight_map.items()
-    ):
-        raise ValueError(f"{index_path}: invalid weight_map entry")
-    referenced = set(weight_map.values())
-    actual = {path.name for path in model_dir.glob("*.safetensors")}
-    if actual != referenced:
-        raise ValueError(
-            f"{model_dir}: safetensors shard set does not match the index"
-        )
-    for shard in sorted(referenced):
-        path = model_dir / shard
-        if not path.is_file() or path.stat().st_size == 0:
-            raise ValueError(f"{path}: indexed shard is missing or empty")
-
-
-def _validate_float_group(group: Mapping[str, object]) -> None:
-    family_conversion.check_members(
-        "quantization_config.config_groups.group_0",
-        group,
-        {"format": "float-quantized", "targets": _FP8_TARGETS},
-    )
-    weights = group.get("weights")
-    activations = group.get("input_activations")
-    if not isinstance(weights, Mapping) or not isinstance(activations, Mapping):
-        raise ValueError("FP8 config is missing weight or activation settings")
-    common = {
-        "num_bits": 8,
-        "type": "float",
-        "group_size": None,
-        "symmetric": True,
-        "scale_dtype": None,
-    }
-    family_conversion.check_members(
-        "quantization_config.config_groups.group_0.weights",
-        weights,
-        {**common, "strategy": "channel", "dynamic": False},
-    )
-    family_conversion.check_members(
-        "quantization_config.config_groups.group_0.input_activations",
-        activations,
-        {**common, "strategy": "token", "dynamic": True},
-    )
-
-
-def _validate_nvfp4_group(group: Mapping[str, object]) -> None:
-    family_conversion.check_members(
-        "quantization_config.config_groups.group_1",
-        group,
-        {"format": "nvfp4-pack-quantized", "targets": _NVFP4_TARGETS},
-    )
-    weights = group.get("weights")
-    activations = group.get("input_activations")
-    if not isinstance(weights, Mapping) or not isinstance(activations, Mapping):
-        raise ValueError("NVFP4 config is missing weight or activation settings")
-    common = {
-        "num_bits": 4,
-        "type": "float",
-        "strategy": "tensor_group",
-        "group_size": 16,
-        "symmetric": True,
-        "scale_dtype": "torch.float8_e4m3fn",
-    }
-    family_conversion.check_members(
-        "quantization_config.config_groups.group_1.weights",
-        weights,
-        {**common, "dynamic": False},
-    )
-    family_conversion.check_members(
-        "quantization_config.config_groups.group_1.input_activations",
-        activations,
-        {**common, "dynamic": "local"},
+def matches_config(config: Mapping[str, object]) -> bool:
+    quantization = config.get("quantization_config")
+    if not isinstance(quantization, Mapping):
+        return False
+    groups = quantization.get("config_groups")
+    if not isinstance(groups, Mapping) or tuple(groups) != ("group_0",):
+        return False
+    group = groups["group_0"]
+    return (
+        quantization.get("format") == "nvfp4-pack-quantized"
+        and isinstance(group, Mapping)
+        and group.get("format") == "nvfp4-pack-quantized"
+        and group.get("targets") == ["Linear"]
     )
 
 
@@ -161,32 +81,50 @@ def _validate_quantized_config(
     summary = family_config.validate_config(config)
     quantization = config.get("quantization_config")
     if not isinstance(quantization, Mapping):
-        raise ValueError("quantized config is missing quantization_config")
+        raise ValueError("QUASAR config is missing quantization_config")
     family_conversion.check_members(
         "quantization_config",
         quantization,
         {
             "quant_method": "compressed-tensors",
             "quantization_status": "compressed",
-            "format": "mixed-precision",
+            "format": "nvfp4-pack-quantized",
+            "ignore": _IGNORED_TARGETS,
         },
     )
     groups = quantization.get("config_groups")
-    if not isinstance(groups, Mapping) or tuple(groups) != (
-        "group_0",
-        "group_1",
-    ):
-        raise ValueError(
-            "quantized config must contain exactly group_0 then group_1"
-        )
-    float_group = groups["group_0"]
-    nvfp4_group = groups["group_1"]
-    if not isinstance(float_group, Mapping) or not isinstance(
-        nvfp4_group, Mapping
-    ):
-        raise ValueError("quantized config groups must be objects")
-    _validate_float_group(float_group)
-    _validate_nvfp4_group(nvfp4_group)
+    if not isinstance(groups, Mapping) or tuple(groups) != ("group_0",):
+        raise ValueError("QUASAR config must contain exactly config_groups.group_0")
+    group = groups["group_0"]
+    if not isinstance(group, Mapping):
+        raise ValueError("QUASAR config group_0 must be an object")
+    family_conversion.check_members(
+        "quantization_config.config_groups.group_0",
+        group,
+        {"format": "nvfp4-pack-quantized", "targets": ["Linear"]},
+    )
+    weights = group.get("weights")
+    activations = group.get("input_activations")
+    if not isinstance(weights, Mapping) or not isinstance(activations, Mapping):
+        raise ValueError("QUASAR config is missing weight or activation settings")
+    common = {
+        "num_bits": 4,
+        "type": "float",
+        "strategy": "tensor_group",
+        "group_size": 16,
+        "symmetric": True,
+        "scale_dtype": "torch.float8_e4m3fn",
+    }
+    family_conversion.check_members(
+        "quantization_config.config_groups.group_0.weights",
+        weights,
+        {**common, "dynamic": False},
+    )
+    family_conversion.check_members(
+        "quantization_config.config_groups.group_0.input_activations",
+        activations,
+        {**common, "dynamic": "local"},
+    )
     return summary
 
 
@@ -208,8 +146,8 @@ def preflight_conversion(
 ) -> ConversionPreflight:
     official = Path(official_dir)
     quantized = Path(quantized_dir)
-    _validate_index(official)
-    _validate_index(quantized)
+    mixed_converter._validate_index(official)
+    mixed_converter._validate_index(quantized)
 
     official_config = family_conversion.load_json(official / "config.json")
     if official_config.get("quantization_config") is not None:
@@ -219,13 +157,14 @@ def preflight_conversion(
         family_conversion.load_json(quantized / "config.json")
     )
     if official_summary != quantized_summary:
-        raise ValueError("official and quantized source model configs do not match")
+        raise ValueError("official and QUASAR source model configs do not match")
     preflight_inventory()
 
     with ShardReader(official) as official_reader:
         official_source = recipe.preflight_official_sources(official_reader)
     with ShardReader(quantized) as quantized_reader:
         quantized_source = recipe.preflight_quantized_metadata(quantized_reader)
+        recipe.validate_nvfp4_words(quantized_reader)
 
     resources = base_convert.load_resources(official)
     resource_map = {resource.name: resource.data for resource in resources}
@@ -244,15 +183,6 @@ def preflight_conversion(
     )
 
 
-def _encode_fp8_weight(
-    spec: inventory.TensorSpec,
-    reader: ShardReader,
-) -> bytes:
-    selected = recipe.FP8_WEIGHTS_BY_NAME[spec.name]
-    codes, scales = recipe.materialize_fp8_weight(selected, reader)
-    return encode_fp8_row_scaled(codes, scales, spec.shape)
-
-
 def _encode_nvfp4_weight(
     spec: inventory.TensorSpec,
     reader: ShardReader,
@@ -262,24 +192,10 @@ def _encode_nvfp4_weight(
     return encode_nvfp4(packed, scales, divisor, spec.shape)
 
 
-def _materialize_direct(
+def _checked_shape(
     spec: inventory.TensorSpec,
-    reader: ShardReader,
+    tensor: torch.Tensor,
 ) -> torch.Tensor:
-    tensor = recipe.materialize_quantized_direct(spec.name, reader)
-    if tuple(tensor.shape) != spec.shape:
-        raise ValueError(
-            f"{spec.name}: materialized shape {tuple(tensor.shape)} != {spec.shape}"
-        )
-    return tensor
-
-
-def _materialize_official(
-    spec: inventory.TensorSpec,
-    reader: ShardReader,
-    derived: Mapping[str, torch.Tensor],
-) -> torch.Tensor:
-    tensor = recipe.materialize_official(spec.name, reader, dict(derived))
     if tuple(tensor.shape) != spec.shape:
         raise ValueError(
             f"{spec.name}: materialized shape {tuple(tensor.shape)} != {spec.shape}"
@@ -339,23 +255,22 @@ def _build_report(
             "tensors": preflight.quantized_source.source_tensor_count,
             "shards": preflight.quantized_source.source_shard_count,
             "dtypes": dict(preflight.quantized_source.source_dtype_counts),
-            "source_fp8_matrices": len(recipe.FP8_SOURCES),
-            "source_nvfp4_matrices": len(recipe.NVFP4_SOURCES),
+            "source_nvfp4_matrices": len(recipe.ALL_NVFP4_SOURCES),
+            "preserved_nvfp4_matrices": len(recipe.NVFP4_SOURCES),
+            "bf16_control_matrices": len(recipe.CONTROL_SOURCES),
         },
     }
-    report["embedding_encoder"] = fp8_embedding.ENCODER_PROFILE
+    report["source_profile"] = "quasar-all-linear-nvfp4"
     return report
 
 
-def _convert_mixed(
+def convert(
     official_dir: str | Path,
     quantized_dir: str | Path,
     out_path: str | Path,
     *,
     device: str | torch.device = "cuda",
 ) -> Path:
-    """Run the closed dual-source conversion and return its report path."""
-
     started = time.perf_counter()
     output = Path(out_path)
     if output.name != OUTPUT_BASENAME:
@@ -368,8 +283,8 @@ def _convert_mixed(
 
     print(
         f"preflight complete: {len(preflight.object_plan.objects)} objects, "
-        f"{len(recipe.FP8_SOURCES)} FP8 and "
-        f"{len(recipe.NVFP4_SOURCES)} NVFP4 source matrices, "
+        f"{len(recipe.NVFP4_SOURCES)} preserved NVFP4 and "
+        f"{len(recipe.CONTROL_SOURCES)} BF16 control source matrices, "
         f"device={resolved_device}",
         flush=True,
     )
@@ -386,36 +301,53 @@ def _convert_mixed(
             preflight.object_plan.specs,
         ) as writer:
             if writer.objects != preflight.object_plan.objects:
-                raise RuntimeError(
-                    "writer object plan differs from completed preflight"
-                )
+                raise RuntimeError("writer object plan differs from completed preflight")
             for index, spec in enumerate(inventory.OBJECT_SPECS, start=1):
                 payload: bytes | Iterable[bytes]
                 if isinstance(spec, inventory.ResourceSpec):
                     payload = resources[spec.name]
-                elif spec.name == "text/token_embedding":
-                    payload = fp8_embedding.iter_reader_payload(
-                        official_reader,
-                        recipe.OFFICIAL_EMBEDDING_SOURCE.name,
-                        spec.shape,
-                    )
-                elif spec.name in recipe.FP8_WEIGHTS_BY_NAME:
-                    payload = _encode_fp8_weight(spec, quantized_reader)
                 elif spec.name in recipe.NVFP4_WEIGHTS_BY_NAME:
                     payload = _encode_nvfp4_weight(spec, quantized_reader)
                 elif spec.name in recipe.INPUT_DIVISORS_BY_NAME:
                     scalar = recipe.materialize_input_divisor(
-                        recipe.INPUT_DIVISORS_BY_NAME[spec.name],
-                        quantized_reader,
+                        recipe.INPUT_DIVISORS_BY_NAME[spec.name], quantized_reader
                     )
                     payload = encode_direct(scalar, inventory.FP32)
+                elif spec.name in recipe.CONTROLS_BY_NAME:
+                    tensor = _checked_shape(
+                        spec,
+                        recipe.materialize_control(
+                            recipe.CONTROLS_BY_NAME[spec.name], quantized_reader
+                        ),
+                    )
+                    payload = encode_direct(tensor, inventory.BF16)
+                    del tensor
                 elif spec.name in recipe.QUANTIZED_DIRECT_BY_NAME:
-                    tensor = _materialize_direct(spec, quantized_reader)
+                    tensor = _checked_shape(
+                        spec,
+                        recipe.materialize_quantized_direct(
+                            spec.name, quantized_reader
+                        ),
+                    )
                     payload = encode_direct(tensor, spec.format)
                     del tensor
+                elif spec.name in recipe.QUANTIZED_MTP_BY_NAME:
+                    tensor = _checked_shape(
+                        spec,
+                        recipe.materialize_quantized_mtp(
+                            spec.name, quantized_reader
+                        ),
+                    )
+                    payload = family_conversion.encode_tensor_payload(
+                        tensor, spec, resolved_device
+                    )
+                    del tensor
                 else:
-                    tensor = _materialize_official(
-                        spec, official_reader, derived
+                    tensor = _checked_shape(
+                        spec,
+                        recipe.materialize_official(
+                            spec.name, official_reader, derived
+                        ),
                     )
                     payload = family_conversion.encode_tensor_payload(
                         tensor, spec, resolved_device
@@ -454,30 +386,6 @@ def _convert_mixed(
         flush=True,
     )
     return report_path
-
-
-def convert(
-    official_dir: str | Path,
-    quantized_dir: str | Path,
-    out_path: str | Path,
-    *,
-    device: str | torch.device = "cuda",
-) -> Path:
-    """Detect the registered quantized source profile and convert it."""
-
-    output = Path(out_path)
-    if output.name != OUTPUT_BASENAME:
-        raise ValueError(
-            f"NVFP4 converter output basename must be {OUTPUT_BASENAME!r}"
-        )
-    config = family_conversion.load_json(Path(quantized_dir) / "config.json")
-    from . import convert_nvfp4_quasar
-
-    if convert_nvfp4_quasar.matches_config(config):
-        return convert_nvfp4_quasar.convert(
-            official_dir, quantized_dir, out_path, device=device
-        )
-    return _convert_mixed(official_dir, quantized_dir, out_path, device=device)
 
 
 def main(argv: Sequence[str] | None = None) -> None:

--- a/tools/convert/qwen3_8_27b/inventory_nvfp4_quasar.py
+++ b/tools/convert/qwen3_8_27b/inventory_nvfp4_quasar.py
@@ -1,0 +1,158 @@
+"""Persistent-object contract for the Qwen3.8-27B QUASAR NVFP4 artifact."""
+
+from __future__ import annotations
+
+from . import inventory_nvfp4 as base
+
+
+MODEL_ID = base.MODEL_ID
+WEIGHTS_ID = base.WEIGHTS_ID
+TARGET_KEY = base.TARGET_KEY
+
+BF16 = base.BF16
+FP32 = base.FP32
+I32 = base.I32
+Q4 = base.Q4
+Q5 = base.Q5
+Q6 = base.Q6
+W8 = base.W8
+NVFP4 = base.NVFP4
+FP8 = base.FP8
+
+CONTIGUOUS_LAYOUT = base.CONTIGUOUS_LAYOUT
+ROW_SPLIT_LAYOUT = base.ROW_SPLIT_LAYOUT
+BLOCK_SCALE_LAYOUT = base.BLOCK_SCALE_LAYOUT
+ROW_SCALE_LAYOUT = base.ROW_SCALE_LAYOUT
+
+ResourceSpec = base.ResourceSpec
+StoredObjectSpec = base.StoredObjectSpec
+TensorSpec = base.TensorSpec
+
+RESOURCE_SPECS = base.RESOURCE_SPECS
+FULL_ATTENTION_LAYERS = base.FULL_ATTENTION_LAYERS
+GDN_LAYERS = base.GDN_LAYERS
+
+
+def tensor_spec(
+    name: str, shape: tuple[int, ...], numeric_format: str
+) -> TensorSpec:
+    return base.tensor_spec(name, shape, numeric_format)
+
+
+def _input_divisor_name(name: str) -> str:
+    prefix, suffix = name.rsplit("/", 1)
+    if suffix == "query_key_gate_value" and prefix.endswith("/attention"):
+        return prefix + "/input_projection/input_scale_divisor"
+    if suffix == "output" and prefix.endswith("/attention"):
+        return prefix + "/output_projection/input_scale_divisor"
+    if suffix == "query_key_value_z" and prefix.endswith("/gdn"):
+        return prefix + "/input_projection/input_scale_divisor"
+    if suffix == "output" and prefix.endswith("/gdn"):
+        return prefix + "/output_projection/input_scale_divisor"
+    if suffix == "gate_up" and prefix.endswith("/mlp"):
+        return prefix + "/gate_up_projection/input_scale_divisor"
+    if suffix == "down" and prefix.endswith("/mlp"):
+        return prefix + "/down_projection/input_scale_divisor"
+    raise ValueError(f"no QUASAR input-divisor role for {name}")
+
+
+def _build_text_core_specs() -> tuple[TensorSpec, ...]:
+    specs: list[TensorSpec] = []
+    for original in base.TEXT_CORE_TENSOR_SPECS:
+        if original.format != FP8:
+            specs.append(original)
+            continue
+        if original.name in ("text/token_embedding", "text/output_head"):
+            specs.append(tensor_spec(original.name, original.shape, W8))
+            continue
+        replacement = tensor_spec(original.name, original.shape, NVFP4)
+        specs.extend(
+            (
+                replacement,
+                tensor_spec(_input_divisor_name(original.name), (), FP32),
+            )
+        )
+    return tuple(specs)
+
+
+TEXT_CORE_TENSOR_SPECS = _build_text_core_specs()
+DRAFT_HEAD_TENSOR_SPECS = base.DRAFT_HEAD_TENSOR_SPECS
+MTP_TENSOR_SPECS = base.MTP_TENSOR_SPECS
+VISION_TENSOR_SPECS = base.VISION_TENSOR_SPECS
+
+TENSOR_SPECS = (
+    TEXT_CORE_TENSOR_SPECS
+    + DRAFT_HEAD_TENSOR_SPECS
+    + MTP_TENSOR_SPECS
+    + VISION_TENSOR_SPECS
+)
+OBJECT_SPECS: tuple[StoredObjectSpec, ...] = RESOURCE_SPECS + TENSOR_SPECS
+
+FORMAT_NAMES = (BF16, FP32, I32, Q4, Q5, Q6, W8, NVFP4, FP8)
+LAYOUT_NAMES = (
+    CONTIGUOUS_LAYOUT,
+    ROW_SPLIT_LAYOUT,
+    BLOCK_SCALE_LAYOUT,
+    ROW_SCALE_LAYOUT,
+)
+FORMAT_COUNTS = {
+    numeric_format: sum(spec.format == numeric_format for spec in TENSOR_SPECS)
+    for numeric_format in FORMAT_NAMES
+}
+LAYOUT_COUNTS = {
+    layout: sum(spec.layout == layout for spec in TENSOR_SPECS)
+    for layout in LAYOUT_NAMES
+}
+
+NVFP4_TENSOR_SPECS = tuple(
+    spec for spec in TENSOR_SPECS if spec.format == NVFP4
+)
+FP8_TENSOR_SPECS = tuple(spec for spec in TENSOR_SPECS if spec.format == FP8)
+INPUT_SCALE_DIVISOR_SPECS = tuple(
+    spec
+    for spec in TENSOR_SPECS
+    if spec.format == FP32 and spec.name.endswith("/input_scale_divisor")
+)
+
+LOGICAL_ROW_VIEW_SPECS = base.LOGICAL_ROW_VIEW_SPECS
+ALIAS_SPECS = base.ALIAS_SPECS
+
+
+def validate_inventory() -> None:
+    names = tuple(spec.name for spec in OBJECT_SPECS)
+    if len(names) != len(set(names)):
+        raise ValueError("QUASAR NVFP4 inventory contains duplicate object names")
+    if (
+        len(TEXT_CORE_TENSOR_SPECS),
+        len(DRAFT_HEAD_TENSOR_SPECS),
+        len(MTP_TENSOR_SPECS),
+        len(VISION_TENSOR_SPECS),
+        len(TENSOR_SPECS),
+        len(OBJECT_SPECS),
+        len(NVFP4_TENSOR_SPECS),
+        len(FP8_TENSOR_SPECS),
+        len(INPUT_SCALE_DIVISOR_SPECS),
+    ) != (915, 2, 12, 333, 1262, 1268, 256, 0, 256):
+        raise ValueError("registered QUASAR NVFP4 inventory is incomplete")
+    if FORMAT_COUNTS != {
+        BF16: 534,
+        FP32: 352,
+        I32: 1,
+        Q4: 55,
+        Q5: 54,
+        Q6: 1,
+        W8: 9,
+        NVFP4: 256,
+        FP8: 0,
+    }:
+        raise ValueError(f"unexpected QUASAR numeric allocation: {FORMAT_COUNTS}")
+    if LAYOUT_COUNTS != {
+        CONTIGUOUS_LAYOUT: 887,
+        ROW_SPLIT_LAYOUT: 119,
+        BLOCK_SCALE_LAYOUT: 256,
+        ROW_SCALE_LAYOUT: 0,
+    }:
+        raise ValueError(f"unexpected QUASAR layout allocation: {LAYOUT_COUNTS}")
+
+
+validate_inventory()

--- a/tools/convert/qwen3_8_27b/recipe_nvfp4_quasar.py
+++ b/tools/convert/qwen3_8_27b/recipe_nvfp4_quasar.py
@@ -1,0 +1,546 @@
+"""Closed dual-source recipe for the Qwen3.8-27B QUASAR NVFP4 artifact."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import struct
+from typing import Iterable
+
+import torch
+
+from tools.artifact.numeric import valid_positive_fp32_word
+from tools.convert.common.safetensors import ShardReader
+from tools.convert.qwen3_6.common import recipe as family_recipe
+from tools.convert.qwen3_6_27b import recipe as official_recipe
+
+from . import inventory_nvfp4_quasar as inventory
+from . import recipe_nvfp4 as shared
+
+
+BASE_REPOSITORY = "Qwen/Qwen3.8-27B"
+BASE_REVISION = "1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0"
+QUANTIZED_REPOSITORY = "QUASAR-QAT/Qwen3.8-27B-QUASAR-NVFP4"
+QUANTIZED_REVISION = "d8e6fbfa3e3a78899b440222b827430045a05b44"
+
+RowRange = shared.RowRange
+MatrixSource = shared.MatrixSource
+MatrixPart = shared.MatrixPart
+Nvfp4WeightRecipe = shared.Nvfp4WeightRecipe
+InputDivisorRecipe = shared.InputDivisorRecipe
+
+
+@dataclass(frozen=True, slots=True)
+class ControlRecipe:
+    object_name: str
+    sources: tuple[MatrixSource, MatrixSource]
+
+
+def _source(name: str, n: int, k: int) -> MatrixSource:
+    return MatrixSource(name, (n, k))
+
+
+def _all(source: MatrixSource) -> MatrixPart:
+    return MatrixPart(source, (RowRange(0, source.shape[0]),))
+
+
+def _q_part(source: MatrixSource, gate: bool) -> MatrixPart:
+    begin = 256 if gate else 0
+    return MatrixPart(
+        source,
+        tuple(
+            RowRange(head * 512 + begin, head * 512 + begin + 256)
+            for head in range(24)
+        ),
+    )
+
+
+def _build_matrix_recipes() -> tuple[
+    tuple[Nvfp4WeightRecipe, ...],
+    tuple[InputDivisorRecipe, ...],
+    tuple[tuple[MatrixSource, ...], ...],
+    tuple[ControlRecipe, ...],
+]:
+    weights: list[Nvfp4WeightRecipe] = []
+    inputs: list[InputDivisorRecipe] = []
+    divisor_groups: list[tuple[MatrixSource, ...]] = []
+    controls: list[ControlRecipe] = []
+
+    def add_weight(
+        object_name: str,
+        shape: tuple[int, int],
+        parts: tuple[MatrixPart, ...],
+        sources: tuple[MatrixSource, ...],
+        input_name: str,
+    ) -> None:
+        weights.append(Nvfp4WeightRecipe(object_name, shape, parts, sources))
+        inputs.append(InputDivisorRecipe(input_name, sources, (object_name,)))
+        if len(sources) > 1:
+            divisor_groups.append(sources)
+
+    for layer in range(64):
+        source_prefix = f"model.language_model.layers.{layer}."
+        object_prefix = f"text/layers/{layer}/"
+        if layer in inventory.FULL_ATTENTION_LAYERS:
+            query = _source(source_prefix + "self_attn.q_proj", 12288, 5120)
+            key = _source(source_prefix + "self_attn.k_proj", 1024, 5120)
+            value = _source(source_prefix + "self_attn.v_proj", 1024, 5120)
+            output = _source(source_prefix + "self_attn.o_proj", 5120, 6144)
+            group = (query, key, value)
+            add_weight(
+                object_prefix + "attention/query_key_gate_value",
+                (14336, 5120),
+                (
+                    _q_part(query, False),
+                    _all(key),
+                    _q_part(query, True),
+                    _all(value),
+                ),
+                group,
+                object_prefix
+                + "attention/input_projection/input_scale_divisor",
+            )
+            add_weight(
+                object_prefix + "attention/output",
+                output.shape,
+                (_all(output),),
+                (output,),
+                object_prefix
+                + "attention/output_projection/input_scale_divisor",
+            )
+        else:
+            query_key_value = _source(
+                source_prefix + "linear_attn.in_proj_qkv", 10240, 5120
+            )
+            z = _source(source_prefix + "linear_attn.in_proj_z", 6144, 5120)
+            output = _source(
+                source_prefix + "linear_attn.out_proj", 5120, 6144
+            )
+            group = (query_key_value, z)
+            add_weight(
+                object_prefix + "gdn/query_key_value_z",
+                (16384, 5120),
+                (_all(query_key_value), _all(z)),
+                group,
+                object_prefix + "gdn/input_projection/input_scale_divisor",
+            )
+            add_weight(
+                object_prefix + "gdn/output",
+                output.shape,
+                (_all(output),),
+                (output,),
+                object_prefix + "gdn/output_projection/input_scale_divisor",
+            )
+            controls.append(
+                ControlRecipe(
+                    object_prefix + "gdn/a_b_projection",
+                    (
+                        _source(
+                            source_prefix + "linear_attn.in_proj_a", 48, 5120
+                        ),
+                        _source(
+                            source_prefix + "linear_attn.in_proj_b", 48, 5120
+                        ),
+                    ),
+                )
+            )
+
+        gate = _source(source_prefix + "mlp.gate_proj", 17408, 5120)
+        up = _source(source_prefix + "mlp.up_proj", 17408, 5120)
+        down = _source(source_prefix + "mlp.down_proj", 5120, 17408)
+        gate_up_group = (gate, up)
+        add_weight(
+            object_prefix + "mlp/gate_up",
+            (34816, 5120),
+            (_all(gate), _all(up)),
+            gate_up_group,
+            object_prefix + "mlp/gate_up_projection/input_scale_divisor",
+        )
+        add_weight(
+            object_prefix + "mlp/down",
+            down.shape,
+            (_all(down),),
+            (down,),
+            object_prefix + "mlp/down_projection/input_scale_divisor",
+        )
+
+    return tuple(weights), tuple(inputs), tuple(divisor_groups), tuple(controls)
+
+
+(
+    NVFP4_WEIGHT_RECIPES,
+    INPUT_DIVISOR_RECIPES,
+    WEIGHT_DIVISOR_GROUPS,
+    CONTROL_RECIPES,
+) = _build_matrix_recipes()
+NVFP4_WEIGHTS_BY_NAME = {
+    item.object_name: item for item in NVFP4_WEIGHT_RECIPES
+}
+INPUT_DIVISORS_BY_NAME = {
+    item.object_name: item for item in INPUT_DIVISOR_RECIPES
+}
+CONTROLS_BY_NAME = {item.object_name: item for item in CONTROL_RECIPES}
+
+NVFP4_SOURCES = tuple(
+    dict.fromkeys(
+        part.source
+        for recipe in NVFP4_WEIGHT_RECIPES
+        for part in recipe.parts
+    )
+)
+CONTROL_SOURCES = tuple(
+    source for recipe in CONTROL_RECIPES for source in recipe.sources
+)
+ALL_NVFP4_SOURCES = tuple(dict.fromkeys(NVFP4_SOURCES + CONTROL_SOURCES))
+
+QUANTIZED_DIRECT_RECIPES = tuple(
+    recipe
+    for recipe in shared.QUANTIZED_DIRECT_RECIPES
+    if recipe.object_name not in CONTROLS_BY_NAME
+)
+QUANTIZED_DIRECT_BY_NAME = {
+    item.object_name: item for item in QUANTIZED_DIRECT_RECIPES
+}
+QUANTIZED_DIRECT_SPECS = tuple(
+    spec
+    for spec in inventory.TEXT_CORE_TENSOR_SPECS
+    if spec.name in QUANTIZED_DIRECT_BY_NAME
+)
+QUANTIZED_MTP_SPECS = inventory.MTP_TENSOR_SPECS
+QUANTIZED_MTP_RECIPES = tuple(
+    official_recipe.RECIPES_BY_NAME[spec.name]
+    for spec in QUANTIZED_MTP_SPECS
+)
+QUANTIZED_MTP_BY_NAME = {
+    item.object_name: item for item in QUANTIZED_MTP_RECIPES
+}
+
+OFFICIAL_TENSOR_SPECS = tuple(
+    spec
+    for spec in inventory.TENSOR_SPECS
+    if spec.name in ("text/token_embedding", "text/output_head")
+    or spec.name.startswith("text/draft_head")
+    or spec.name.startswith("vision/")
+)
+OFFICIAL_RECIPES = tuple(
+    official_recipe.RECIPES_BY_NAME[spec.name]
+    for spec in OFFICIAL_TENSOR_SPECS
+)
+OFFICIAL_RECIPES_BY_NAME = {
+    item.object_name: item for item in OFFICIAL_RECIPES
+}
+
+
+def _validate_matrix_recipe(recipe: Nvfp4WeightRecipe) -> None:
+    rows = sum(part.output_rows for part in recipe.parts)
+    if not recipe.parts or (rows, recipe.parts[0].source.shape[1]) != recipe.shape:
+        raise ValueError(f"{recipe.object_name}: invalid fused row geometry")
+    if any(part.source.shape[1] != recipe.shape[1] for part in recipe.parts):
+        raise ValueError(f"{recipe.object_name}: incompatible source K")
+
+
+def validate_recipe() -> None:
+    family_recipe.validate_recipe_coverage(
+        QUANTIZED_DIRECT_RECIPES, QUANTIZED_DIRECT_SPECS
+    )
+    family_recipe.validate_recipe_coverage(
+        QUANTIZED_MTP_RECIPES, QUANTIZED_MTP_SPECS
+    )
+    family_recipe.validate_recipe_coverage(
+        OFFICIAL_RECIPES, OFFICIAL_TENSOR_SPECS
+    )
+    if (
+        len(NVFP4_WEIGHT_RECIPES),
+        len(INPUT_DIVISOR_RECIPES),
+        len(WEIGHT_DIVISOR_GROUPS),
+        len(NVFP4_SOURCES),
+        len(CONTROL_RECIPES),
+        len(CONTROL_SOURCES),
+        len(ALL_NVFP4_SOURCES),
+        len(QUANTIZED_DIRECT_RECIPES),
+        len(QUANTIZED_MTP_RECIPES),
+        len(OFFICIAL_RECIPES),
+    ) != (256, 256, 128, 400, 48, 96, 496, 353, 12, 337):
+        raise ValueError("Qwen3.8 QUASAR NVFP4 source recipe is incomplete")
+    ownership = (
+        set(NVFP4_WEIGHTS_BY_NAME),
+        set(INPUT_DIVISORS_BY_NAME),
+        set(CONTROLS_BY_NAME),
+        set(QUANTIZED_DIRECT_BY_NAME),
+        set(QUANTIZED_MTP_BY_NAME),
+        set(OFFICIAL_RECIPES_BY_NAME),
+    )
+    all_names: set[str] = set()
+    for names in ownership:
+        if all_names.intersection(names):
+            raise ValueError("more than one source route owns an artifact tensor")
+        all_names.update(names)
+    if all_names != {spec.name for spec in inventory.TENSOR_SPECS}:
+        raise ValueError("source routes do not cover the QUASAR tensor inventory")
+    if tuple(NVFP4_WEIGHTS_BY_NAME) != tuple(
+        spec.name for spec in inventory.NVFP4_TENSOR_SPECS
+    ):
+        raise ValueError("QUASAR NVFP4 recipe order does not match inventory")
+    if tuple(INPUT_DIVISORS_BY_NAME) != tuple(
+        spec.name for spec in inventory.INPUT_SCALE_DIVISOR_SPECS
+    ):
+        raise ValueError("QUASAR input-divisor order does not match inventory")
+    for recipe in NVFP4_WEIGHT_RECIPES:
+        _validate_matrix_recipe(recipe)
+    bound_weights = tuple(
+        name for site in INPUT_DIVISOR_RECIPES for name in site.weight_names
+    )
+    if len(bound_weights) != 256 or set(bound_weights) != set(
+        NVFP4_WEIGHTS_BY_NAME
+    ):
+        raise ValueError("QUASAR input-divisor sites do not cover NVFP4 parents")
+
+
+def _merge_requirement(
+    result: dict[str, tuple[tuple[int, ...], str]],
+    name: str,
+    shape: tuple[int, ...],
+    dtype: str,
+) -> None:
+    signature = (shape, dtype)
+    previous = result.setdefault(name, signature)
+    if previous != signature:
+        raise ValueError(f"inconsistent QUASAR source declaration for {name}")
+
+
+def _source_requirements() -> dict[str, tuple[tuple[int, ...], str]]:
+    result: dict[str, tuple[tuple[int, ...], str]] = {}
+    for source in ALL_NVFP4_SOURCES:
+        n, k = source.shape
+        _merge_requirement(
+            result, source.field("weight_packed"), (n, k // 2), "U8"
+        )
+        _merge_requirement(
+            result, source.field("weight_scale"), (n, k // 16), "F8_E4M3"
+        )
+        _merge_requirement(
+            result, source.field("weight_global_scale"), (1,), "F32"
+        )
+        _merge_requirement(
+            result, source.field("input_global_scale"), (1,), "F32"
+        )
+    for source in family_recipe.source_requirements(
+        QUANTIZED_DIRECT_RECIPES + QUANTIZED_MTP_RECIPES
+    ).values():
+        _merge_requirement(result, source.name, source.shape, source.dtype)
+    return result
+
+
+SOURCE_REQUIREMENTS = _source_requirements()
+EXPECTED_QUANTIZED_FIELDS = frozenset(
+    source.field(suffix)
+    for source in ALL_NVFP4_SOURCES
+    for suffix in (
+        "weight_packed",
+        "weight_scale",
+        "weight_global_scale",
+        "input_global_scale",
+    )
+)
+
+
+def preflight_quantized_metadata(
+    reader: ShardReader,
+) -> family_recipe.SourcePreflight:
+    missing = set(SOURCE_REQUIREMENTS).difference(reader.names)
+    if missing:
+        raise ValueError(f"QUASAR source is missing {sorted(missing)[0]}")
+    metadata = reader.metadata(reader.names)
+    actual_quantized_fields = frozenset(
+        name
+        for name, item in metadata.items()
+        if item.dtype in ("F8_E4M3", "F32", "U8")
+        and any(
+            name.endswith("." + suffix)
+            for suffix in (
+                "weight_packed",
+                "weight_scale",
+                "weight_global_scale",
+                "input_global_scale",
+            )
+        )
+    )
+    if actual_quantized_fields != EXPECTED_QUANTIZED_FIELDS:
+        unexpected = actual_quantized_fields.difference(EXPECTED_QUANTIZED_FIELDS)
+        absent = EXPECTED_QUANTIZED_FIELDS.difference(actual_quantized_fields)
+        detail = sorted(unexpected or absent)[0]
+        raise ValueError(f"QUASAR source allocation is not closed: {detail}")
+
+    dtype_counts: dict[str, int] = {}
+    shards: set[str] = set()
+    for name, (shape, dtype) in SOURCE_REQUIREMENTS.items():
+        actual = metadata[name]
+        if actual.shape != shape or actual.dtype != dtype:
+            raise ValueError(
+                f"{name}: source signature {(actual.shape, actual.dtype)} "
+                f"!= {(shape, dtype)}"
+            )
+        dtype_counts[dtype] = dtype_counts.get(dtype, 0) + 1
+        shards.add(actual.shard)
+    return family_recipe.SourcePreflight(
+        recipe_count=(
+            len(NVFP4_WEIGHT_RECIPES)
+            + len(INPUT_DIVISOR_RECIPES)
+            + len(CONTROL_RECIPES)
+            + len(QUANTIZED_DIRECT_RECIPES)
+            + len(QUANTIZED_MTP_RECIPES)
+        ),
+        source_tensor_count=len(SOURCE_REQUIREMENTS),
+        source_shard_count=len(shards),
+        source_dtype_counts=dtype_counts,
+    )
+
+
+def preflight_official_sources(
+    reader: ShardReader,
+) -> family_recipe.SourcePreflight:
+    return family_recipe.preflight_source_reader(reader, OFFICIAL_RECIPES)
+
+
+def _word(tensor: torch.Tensor, name: str) -> int:
+    if tensor.dtype != torch.float32 or tensor.numel() != 1:
+        raise ValueError(f"{name}: divisor must be FP32[1]")
+    word = int(tensor.detach().contiguous().cpu().view(torch.int32).item())
+    word &= 0xFFFFFFFF
+    if not valid_positive_fp32_word(word):
+        raise ValueError(f"{name}: divisor must be finite and positive")
+    return word
+
+
+def _same_divisor(
+    reader: ShardReader,
+    sources: Iterable[MatrixSource],
+    suffix: str,
+) -> int:
+    items = tuple(sources)
+    words = tuple(
+        _word(reader.get(source.field(suffix)), source.field(suffix))
+        for source in items
+    )
+    if len(set(words)) != 1:
+        raise ValueError(f"{items[0].name}: fused {suffix} words differ")
+    return words[0]
+
+
+def validate_nvfp4_words(reader: ShardReader) -> None:
+    for source in ALL_NVFP4_SOURCES:
+        scales = reader.get(source.field("weight_scale")).view(torch.uint8)
+        invalid = ((scales & 0x80) != 0) | (scales == 0x7F)
+        if bool(invalid.any()):
+            raise ValueError(
+                f"{source.field('weight_scale')}: invalid E4M3FN scale word"
+            )
+        _word(
+            reader.get(source.field("weight_global_scale")),
+            source.field("weight_global_scale"),
+        )
+        _word(
+            reader.get(source.field("input_global_scale")),
+            source.field("input_global_scale"),
+        )
+    for group in WEIGHT_DIVISOR_GROUPS:
+        _same_divisor(reader, group, "weight_global_scale")
+    for recipe in INPUT_DIVISOR_RECIPES:
+        _same_divisor(reader, recipe.sources, "input_global_scale")
+
+
+def materialize_nvfp4_weight(
+    recipe: Nvfp4WeightRecipe,
+    reader: ShardReader,
+) -> tuple[torch.Tensor, torch.Tensor, bytes]:
+    return shared.materialize_nvfp4_weight(recipe, reader)
+
+
+def materialize_input_divisor(
+    recipe: InputDivisorRecipe,
+    reader: ShardReader,
+) -> torch.Tensor:
+    word = _same_divisor(reader, recipe.sources, "input_global_scale")
+    return torch.frombuffer(
+        bytearray(struct.pack("<I", word)), dtype=torch.float32
+    ).reshape(())
+
+
+def _decode_nvfp4_source(
+    source: MatrixSource,
+    reader: ShardReader,
+) -> torch.Tensor:
+    packed = reader.get(source.field("weight_packed")).to(torch.uint8)
+    codes = torch.empty(source.shape, dtype=torch.uint8)
+    codes[:, 0::2] = packed & 0x0F
+    codes[:, 1::2] = packed >> 4
+    lookup = torch.tensor(
+        (
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ),
+        dtype=torch.float32,
+    )
+    scales = reader.get(source.field("weight_scale")).to(torch.float32)
+    divisor = reader.get(source.field("weight_global_scale")).to(torch.float32)
+    decoded = lookup[codes.to(torch.long)]
+    decoded *= scales.repeat_interleave(16, dim=1)
+    decoded /= divisor
+    return decoded.to(torch.bfloat16)
+
+
+def materialize_control(
+    recipe: ControlRecipe,
+    reader: ShardReader,
+) -> torch.Tensor:
+    value = torch.cat(
+        tuple(_decode_nvfp4_source(source, reader) for source in recipe.sources),
+        dim=0,
+    )
+    if tuple(value.shape) != (96, 5120):
+        raise ValueError(f"{recipe.object_name}: decoded control shape mismatch")
+    return value
+
+
+def materialize_quantized_direct(
+    object_name: str,
+    reader: ShardReader,
+) -> torch.Tensor:
+    return family_recipe.materialize_recipe(
+        QUANTIZED_DIRECT_BY_NAME[object_name], reader
+    )
+
+
+def materialize_quantized_mtp(
+    object_name: str,
+    reader: ShardReader,
+) -> torch.Tensor:
+    return family_recipe.materialize_recipe(
+        QUANTIZED_MTP_BY_NAME[object_name], reader
+    )
+
+
+def materialize_official(
+    object_name: str,
+    reader: ShardReader,
+    derived_tensors: dict[str, torch.Tensor] | None = None,
+) -> torch.Tensor:
+    return family_recipe.materialize_recipe(
+        OFFICIAL_RECIPES_BY_NAME[object_name], reader, derived_tensors
+    )
+
+
+validate_recipe()


### PR DESCRIPTION
Detect the all-linear compressed-tensors source and preserve supported NVFP4 words in a dedicated artifact profile. Decode narrow GDN controls to BF16 and add runtime selection, contract documentation, and focused tests.

# AIME 2025

30/30 100%

```json
{
    "name": "qwen3.8-27b@aime25",
    "dataset_name": "aime25",
    "dataset_pretty_name": "AIME-2025",
    "dataset_description": "\n## Overview\n\nAIME 2025 (American Invitational Mathematics Examination 2025) is a benchmark based on problems from the prestigious AIME competition, one of the most challenging high school mathematics contests in the United States. It tests advanced mathematical reasoning and problem-solving skills.\n\n## Task Description\n\n- **Task Type**: Competition Mathematics Problem Solving\n- **Input**: AIME-level mathematical problem\n- **Output**: Integer answer (0-999) with step-by-step reasoning\n- **Difficulty**: Advanced high school / early undergraduate level\n\n## Key Features\n\n- Problems from AIME I and AIME II 2025 competitions\n- Answers are always integers between 0 and 999\n- Requires creative mathematical reasoning and problem-solving\n- Topics: algebra, geometry, number theory, combinatorics, probability\n- Represents top-tier high school mathematics competition difficulty\n\n## Evaluation Notes\n\n- Default configuration uses **0-shot** evaluation\n- Answers should be formatted within `\\boxed{}` for proper extraction\n- Uses LLM-as-judge for mathematical equivalence checking\n",
    "model_name": "qwen3.8-27b",
    "score": 1.0,
    "metrics": [
        {
            "name": "mean_acc",
            "num": 30,
            "score": 1.0,
            "macro_score": 1.0,
            "categories": [
                {
                    "name": [
                        "default"
                    ],
                    "num": 30,
                    "score": 1.0,
                    "macro_score": 1.0,
                    "subsets": [
                        {
                            "name": "default",
                            "score": 1.0,
                            "num": 30,
                            "is_aggregate": false
                        }
                    ]
                }
            ]
        }
    ],
    "analysis": "N/A",
    "perf_metrics": {
        "summary": {
            "n_samples": 30,
            "latency": {
                "mean": 327.687875,
                "std": 458.460898,
                "min": 9.572903,
                "25%": 37.10061,
                "50%": 175.774639,
                "75%": 408.770131,
                "90%": 779.239053,
                "99%": 1824.37179,
                "max": 1936.069401
            },
            "throughput": {
                "avg_output_tps": 73.85,
                "avg_req_ps": 0.0031
            },
            "usage": {
                "input_tokens": {
                    "mean": 253.9,
                    "std": 185.05849,
                    "min": 108.0,
                    "25%": 159.25,
                    "50%": 185.5,
                    "75%": 257.25,
                    "90%": 570.0,
                    "99%": 836.5,
                    "max": 909.0
                },
                "output_tokens": {
                    "mean": 24198.633333,
                    "std": 29594.242325,
                    "min": 1006.0,
                    "25%": 3475.75,
                    "50%": 14158.0,
                    "75%": 32165.5,
                    "90%": 57409.9,
                    "99%": 114441.44,
                    "max": 120753.0
                },
                "total_tokens": {
                    "mean": 24452.533333,
                    "std": 29625.192399,
                    "min": 1122.0,
                    "25%": 3652.25,
                    "50%": 14337.0,
                    "75%": 32327.25,
                    "90%": 57940.3,
                    "99%": 114636.91,
                    "max": 120965.0
                },
                "total_input_tokens": 7617,
                "total_output_tokens": 725959,
                "total_tokens_count": 733576
            }
        }
    },
    "num": 30
}
```

https://arxiv.org/abs/2608.13966

```bibtex
@article{counathe2026quasar,
  title={QUASAR: Lowering the Loss Floor of Quantization-Aware Training with Loss-Aware Reconstruction},
  author={Counathe, Vincent and Athiwaratkun, Ben and De Sa, Christopher and Zhang, Tianyi},
  journal={arXiv preprint arXiv:2608.13966},
  year={2026}
}
```