### PR TITLE
ci: add CPU validation workflows

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,45 @@
+name: Clang Format
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends clang-format-18
+
+      - name: Check formatting
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            BASE_SHA="${GITHUB_SHA}^"
+          fi
+          mapfile -d '' sources < <(
+            git diff --name-only -z --diff-filter=ACMR "$BASE_SHA" "$GITHUB_SHA" -- \
+              '*.c' '*.cc' '*.cpp' '*.cxx' \
+              '*.h' '*.hh' '*.hpp' '*.hxx' \
+              '*.cu' '*.cuh' \
+              ':(exclude)third_party/**'
+          )
+          if ((${#sources[@]})); then
+            clang-format-18 \
+              --dry-run --Werror --style=file --fallback-style=none \
+              "${sources[@]}"
+          fi

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -1,0 +1,35 @@
+name: CPU Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tests/requirements-cpu.txt
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu "torch==2.7.1"
+          python -m pip install -r tests/requirements-cpu.txt
+
+      - name: Run CPU tests
+        run: |
+          python -m pytest tests
+          PYTHONPATH=eval python -m unittest discover -s eval/tests -p 'test_*.py'

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,19 +92,21 @@ whole suite; private kernel, schedule, launcher, and T selection do not change i
 files call public `linear()` and contain no private selector, launcher, schedule, or kernel
 assertions.
 
-Run the native Python suites with the project Python environment:
+Run all self-contained CPU tests with Python 3.11 and the dependencies used by CI:
 
 ```bash
-python3 -m pytest \
-  tests/artifact tests/targets/qwen3_6_27b tests/targets/qwen3_6_35b_a3b \
-  tests/test_bench_matrix.py tests/test_serve_corpus.py
+python3 -m pip install --index-url https://download.pytorch.org/whl/cpu "torch==2.7.1"
+python3 -m pip install -r tests/requirements-cpu.txt
+python3 -m pytest tests
+PYTHONPATH=eval python3 -m unittest discover -s eval/tests -p 'test_*.py'
 ```
 
 The Python binding tests use `NINFER_QWEN3_6_27B_ARTIFACT` when set, otherwise they look for
 `out/qwen3_6_27b.ninfer`. They report a pytest skip when neither path provides the real
 artifact. The 35B-A3B reference binding test follows the same rule with
 `NINFER_QWEN3_6_35B_A3B_ARTIFACT` and `out/qwen3_6_35b_a3b.ninfer`. The remaining Python
-target tests still run without either artifact.
+target tests still run without either artifact. Tests against local official checkpoint resources
+are also skipped when those checkpoint directories are unavailable.
 
 The C++ prefix/MTP integration test is separately opt-in because it loads the full artifact and
 runs the real engine:

--- a/tests/requirements-cpu.txt
+++ b/tests/requirements-cpu.txt
@@ -1,0 +1,6 @@
+# PyTorch 2.7.1 is installed separately from its CPU-only wheel index.
+numpy>=1.24
+pytest>=8
+PyYAML==6.0.3
+rich==15.0.0
+safetensors>=0.4

--- a/tests/targets/qwen3_6_27b/test_convert.py
+++ b/tests/targets/qwen3_6_27b/test_convert.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 import torch
 
 from tools.artifact.container import (
@@ -22,6 +23,10 @@ OFFICIAL_MODEL = Path(
 )
 
 
+@pytest.mark.skipif(
+    not (OFFICIAL_MODEL / "config.json").is_file(),
+    reason="the local official Qwen3.6-27B checkpoint is unavailable",
+)
 def test_official_config_uses_only_nested_mtp_field():
     config = json.loads((OFFICIAL_MODEL / "config.json").read_text())
 

--- a/tests/targets/qwen3_6_27b/test_official_resources.py
+++ b/tests/targets/qwen3_6_27b/test_official_resources.py
@@ -28,6 +28,8 @@ UNSLOTH_TOKENIZER_SHA256 = (
     ((convert_27b.load_resources, MODEL_27B), (convert_35b.load_resources, MODEL_35B)),
 )
 def test_both_official_sources_pass_the_shared_preflight(loader, model_dir):
+    if not model_dir.is_dir():
+        pytest.skip(f"the local official checkpoint is unavailable at {model_dir}")
     resources = loader(model_dir)
 
     assert tuple(resource.name for resource in resources) == tuple(

--- a/tests/targets/qwen3_6_27b/test_reference_frontend.py
+++ b/tests/targets/qwen3_6_27b/test_reference_frontend.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from tools.reference.qwen3_6.common.frontend import Frontend
 
 
 MODEL = Path("/home/neroued/models/llm/qwen/Qwen3.6-27B/base-hf-bf16")
+pytestmark = pytest.mark.skipif(
+    not MODEL.is_dir(),
+    reason="the local official Qwen3.6-27B checkpoint is unavailable",
+)
 CONFIG_ONLY_TOKENS = {
     "<|audio_start|>": 248070,
     "<|audio_end|>": 248071,


### PR DESCRIPTION
## Summary
- add an incremental clang-format 18 check for changed project-owned C/C++/CUDA files
- run the self-contained Python and evaluation coordinator test suites on CPU-only GitHub runners
- skip local-checkpoint tests when their explicit fixtures are unavailable

## Verification
- `python -m pytest tests`: 89 passed, 7 skipped
- `PYTHONPATH=eval python -m unittest discover -s eval/tests -p 'test_*.py'`: 19 passed
- workflow YAML parse and `git diff --check` passed