### PR TITLE
fix(runtime): refresh dflash prefill state slot after checkpoint forks

### DIFF
--- a/src/targets/qwen3_6/impl/runtime/text_prefill_impl.h
+++ b/src/targets/qwen3_6/impl/runtime/text_prefill_impl.h
@@ -23,6 +23,8 @@ DFlashFeatureSink make_dflash_prefill_sink(PrefillContext& state) {
             Tensor count = frame.append_counts.slice(0, 0, 1);
             Tensor lane  = frame.state_destination_slots.slice(0, 0, 1);
             Tensor row   = frame.dflash_kv_table_rows.slice(0, 0, 1);
+            // A checkpoint fork can move the active StateImage between prefill chunks.
+            ops::set_i32_scalar(lane, state.state_destination_slot, state.execution.device.stream);
             ops::set_i32_scalar(count, features.ne[1], state.execution.device.stream);
             const auto exact = static_cast<std::uint32_t>(features.ne[1]);
             dflash_append_context(state, features, positions, count, lane, row, {exact, exact});

--- a/tests/targets/qwen3_6_27b/test_engine_dflash2_real.cpp
+++ b/tests/targets/qwen3_6_27b/test_engine_dflash2_real.cpp
@@ -104,6 +104,52 @@ int main(int argc, char** argv) {
         options.speculative.draft_tokens = k;
         options.speculative.proposal_head =
             optimized ? ninfer::ProposalHead::Optimized : ninfer::ProposalHead::Full;
+        // Keep prompt splits fixed while changing checkpoint placement. Drafter suffix writes
+        // must follow a Device fork to its new slot, just as they follow a Host snapshot in place.
+        std::vector<ninfer::TokenId> host_capture_tokens;
+        for (const unsigned device_slots : {0U, 1U}) {
+            auto capture_options            = options;
+            capture_options.max_concurrency = 1;
+            capture_options.kv_capacity     = ninfer::KvCapacityPolicy::explicit_capacity(2304);
+            capture_options.enable_vision   = false;
+            capture_options.context_cache.device_state_slots  = device_slots;
+            capture_options.context_cache.host_state_slots    = 8;
+            capture_options.context_cache.max_shared_prefixes = 0;
+            ninfer::Engine capture_engine(capture_options);
+            ninfer::ChatMessage user;
+            user.role = ninfer::ChatRole::User;
+            user.parts.push_back(
+                {.kind = ninfer::MessagePartKind::Text,
+                 .text =
+                     "\nSolve the following math problem step by step. Put your answer inside "
+                     "\\boxed{}.\n\n"
+                     "Six points $A, B, C, D, E,$ and $F$ lie in a straight line in that order. "
+                     "Suppose that $G$ is a point not on the line and that $AC=26, BD=22, CE=31, "
+                     "DF=33, AF=73, CG=40,$ and $DG=30.$ Find the area of $\\triangle BGE.$\n\n"
+                     "Remember to put your answer inside \\boxed{}.",
+                 .media = {}});
+            ninfer::PromptInput input;
+            input.messages.push_back(std::move(user));
+            input.options.enable_thinking                  = true;
+            auto sampled_capture                           = request(128, true);
+            sampled_capture.execution.sampling.temperature = 1.0F;
+            sampled_capture.execution.sampling.top_p       = 0.95F;
+            sampled_capture.execution.sampling.top_k       = 20;
+            sampled_capture.execution.sampling.seed        = 42;
+            const auto result =
+                capture_engine.generate(capture_engine.prepare(input), sampled_capture);
+            valid(result, 128);
+            const auto capture_stats = capture_engine.runtime_stats();
+            require(device_slots == 0 ? capture_stats.state_d2h_count > 0
+                                      : capture_stats.state_forks > 0,
+                    "sampled capture fixture did not exercise its StateImage placement");
+            if (device_slots == 0) {
+                host_capture_tokens = result.generated_token_ids;
+            } else {
+                require(result.generated_token_ids == host_capture_tokens,
+                        "DFlash2 sampled output changed across Host/Device checkpoint placement");
+            }
+        }
         ninfer::Engine engine(options);
         ninfer::test::speculative_page_boundary(engine);
         const auto first = engine.generate(engine.prepare_tokens(prompt), request(24));


### PR DESCRIPTION
## Fix
A prefill checkpoint can fork the active StateImage into a new physical slot. The DFlash/DFlash2 feature-sink callback was still using the destination selector initialized in the decode frame at request admission. Subsequent context appends could therefore write into the frozen source checkpoint instead of the active destination, leaving the drafter suffix incomplete.

Refresh the device destination selector from the current PrefillContext before every context append.

## Regression Test
Extend the existing opt-in real DFlash2 Engine test with a seeded 128-token request evaluated under Host snapshot and Device fork placement. Disable shared captures to hold prompt splits fixed, assert that each placement was actually exercised, and compare the complete generated token IDs. This tests placement invariance, not whether the model solves the math fixture correctly.

## Validation
Built independently from current master (`d4bc75db`) on RTX 5090 Laptop GPU, CUDA 13.1, GCC 15.3, Release/sm_120a, using the local Qwen3.8 QUASAR NVFP4 artifact with DFlash2 companion weights.

With the regression added but WITHOUT the fix, `7 1 0 1 int8` fails with:
```
DFlash2 sampled output changed across Host/Device checkpoint placement
```

WITH the fix, both complete test invocations pass:
```bash
export NINFER_QWEN3_8_27B_DFLASH2_WEIGHTS=/path/to/quasar-dflash2.ninfer
./build/tests/ninfer_qwen3_8_27b_dflash2_real_test 7 1 0 1 int8
./build/tests/ninfer_qwen3_8_27b_dflash2_real_test 15 0 1 2 bf16
```

These cover K7/Graph/full-head/INT8 and K15/eager/optimized-head/BF16, including the new placement regression and existing integration checks. `git diff --check` passes. The 35B-A3B DFlash real-artifact route was not run.

## Scope
Only the selector fix and coupled regression test: two files, 48 added lines. No KVarN changes, RoPE fixes, cache-policy changes, or benchmark artifacts. This does not change adaptive shared-capture split selection or claim to eliminate numerical differences between different prefill decompositions.